### PR TITLE
Remove reference potential energy calculation for 3D

### DIFF
--- a/src/3d/parcels/parcel_diagnostics_netcdf.f90
+++ b/src/3d/parcels/parcel_diagnostics_netcdf.f90
@@ -86,7 +86,7 @@ module parcel_diagnostics_netcdf
 
             call define_netcdf_temporal_dimension(ncid, t_dim_id, t_axis_id)
 
-            if (.not. ape_calculation == 'none') then
+            if (ape_calculation == 'ape density') then
                 call define_netcdf_dataset(                                 &
                     ncid=ncid,                                              &
                     name='ape',                                             &
@@ -281,7 +281,7 @@ module parcel_diagnostics_netcdf
 
             call get_var_id(ncid, 't', t_axis_id)
 
-            if (.not. ape_calculation == 'none') then
+            if (ape_calculation == 'ape density') then
                 call get_var_id(ncid, 'ape', ape_id)
             endif
 
@@ -349,7 +349,7 @@ module parcel_diagnostics_netcdf
             !
             ! write diagnostics
             !
-            if (.not. ape_calculation == 'none') then
+            if (ape_calculation == 'ape density') then
                 call write_netcdf_scalar(ncid, ape_id, parcel_stats(IDX_APE), n_writes)
             endif
             call write_netcdf_scalar(ncid, ke_id, parcel_stats(IDX_KE), n_writes)

--- a/src/3d/utils/utils.f90
+++ b/src/3d/utils/utils.f90
@@ -20,7 +20,7 @@ module utils
     use netcdf_reader, only : get_file_type, get_num_steps, get_time, get_netcdf_box
     use parameters, only : lower, extent, update_parameters, read_zeta_boundary_flag &
                          , set_zeta_boundary_flag
-    use physics, only : read_physical_quantities, print_physical_quantities, l_peref
+    use physics, only : read_physical_quantities, print_physical_quantities
     implicit none
 
     integer :: nfw  = 0    ! number of field writes
@@ -34,10 +34,6 @@ module utils
 
         ! Create NetCDF files and set the step number
         subroutine setup_output_files
-
-            if (.not. l_peref) then
-                call calculate_peref
-            endif
 
             if (output%write_parcel_stats) then
                 call create_netcdf_parcel_stats_file(trim(output%basename), &

--- a/unit-tests/3d/test_mpi_parcel_diagnostics.f90
+++ b/unit-tests/3d/test_mpi_parcel_diagnostics.f90
@@ -74,9 +74,6 @@ program test_mpi_parcel_diagnostics
     parcels%vorticity(:, 1:n_parcels) = f12
     velocity(:, 1:n_parcels)  = f12
 
-    ! calculates reference potential energy
-    call calculate_peref
-
     call calculate_parcel_diagnostics(velocity)
 
     if (comm%rank == comm%master) then


### PR DESCRIPTION
We remove the peref calculation for 3D as the result is too inaccurate and the calculation involves a global sort across all MPI ranks which we do not want to do.

Closes #370.