### PR TITLE
Make RK4 variables part of the parcel container

### DIFF
--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -27,7 +27,7 @@ program epic3d
     use inversion_utils, only : init_inversion
     use parcel_interpl, only : grid2par_timer, par2grid_timer
     use parcel_init, only : init_timer
-    use ls_rk4, only : ls_rk4_alloc, ls_rk4_dealloc, ls_rk4_step, rk4_timer
+    use ls_rk4, only : ls_rk4_step, rk4_timer
     use utils, only : write_last_step, setup_output_files        &
                     , setup_restart, setup_domain_and_parameters &
                     , setup_fields_and_parcels
@@ -90,8 +90,6 @@ program epic3d
 
             call setup_fields_and_parcels
 
-            call ls_rk4_alloc(max_num_parcels)
-
             call init_inversion
 
             call initialise_pencil_fft(nx, ny, nz)
@@ -146,7 +144,6 @@ program epic3d
         subroutine post_run
             use options, only : output
             call parcel_dealloc
-            call ls_rk4_dealloc
             call finalise_pencil_fft
             call stop_timer(epic_timer)
 

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -31,7 +31,6 @@ program epic3d
     use utils, only : write_last_step, setup_output_files        &
                     , setup_restart, setup_domain_and_parameters &
                     , setup_fields_and_parcels
-    use parameters, only : max_num_parcels
     use mpi_communicator, only : mpi_comm_initialise, mpi_comm_finalise
     use fft_pencil, only : initialise_pencil_fft, finalise_pencil_fft
     implicit none

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -28,7 +28,7 @@ module parcel_container
                           IDX_VOL,          & ! volume
                           IDX_BUO,          & ! buoyancy
 #ifndef ENABLE_DRY_MODE
-    integer, protected :: IDX_HUM,          & ! humidity
+                          IDX_HUM,          & ! humidity
 #endif
                           IDX_RK4_X_DPOS,   & ! RK4 variable delta x-position
                           IDX_RK4_Y_DPOS,   & ! RK4 variable delta y-position
@@ -65,6 +65,15 @@ module parcel_container
             humidity,   &
 #endif
             buoyancy
+
+
+        ! LS-RK4 variables
+        double precision, allocatable, dimension(:, :) :: &
+            delta_pos,  &
+            delta_vor,  &
+            strain,     &
+            delta_b
+
     end type parcel_container_type
 
     type(parcel_container_type) parcels

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -183,6 +183,12 @@ module parcel_container
             allocate(parcels%humidity(num))
 #endif
             call parcel_ellipsoid_allocate(num)
+
+            ! LS-RK4 variables
+            allocate(parcels%delta_pos(3, num))
+            allocate(parcels%delta_vor(3, num))
+            allocate(parcels%strain(5, num))
+            allocate(parcels%delta_b(5, num))
         end subroutine parcel_alloc
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -210,6 +216,13 @@ module parcel_container
             deallocate(parcels%humidity)
 #endif
             call parcel_ellipsoid_deallocate
+
+            ! LS-RK4 variables
+            deallocate(parcels%delta_pos)
+            deallocate(parcels%delta_vor)
+            deallocate(parcels%strain)
+            deallocate(parcels%delta_b)
+
         end subroutine parcel_dealloc
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -32,7 +32,7 @@ module parcel_container
 #endif
                           IDX_RK4_X_DPOS,   & ! RK4 variable delta x-position
                           IDX_RK4_Y_DPOS,   & ! RK4 variable delta y-position
-                          IDX_RK4_Z_DPOX,   & ! RK4 variable delta z-position
+                          IDX_RK4_Z_DPOS,   & ! RK4 variable delta z-position
                           IDX_RK4_X_DVOR,   & ! RK4 variable delta x-vorticity
                           IDX_RK4_Y_DVOR,   & ! RK4 variable delta y-vorticity
                           IDX_RK4_Z_DVOR,   & ! RK4 variable delta z-vorticity
@@ -110,7 +110,7 @@ module parcel_container
             ! LS-RK4 variables
             IDX_RK4_X_DPOS = i
             IDX_RK4_Y_DPOS = i + 1
-            IDX_RK4_Z_DPOX = i + 2
+            IDX_RK4_Z_DPOS = i + 2
             IDX_RK4_X_DVOR = i + 3
             IDX_RK4_Y_DVOR = i + 4
             IDX_RK4_Z_DVOR = i + 5
@@ -315,7 +315,7 @@ module parcel_container
             buffer(IDX_HUM)             = parcels%humidity(n)
 #endif
             ! LS-RK4 variables:
-            buffer(IDX_RK4_X_DPOS:IDX_RK4_Z_DPOX) = parcels%delta_pos(:, n)
+            buffer(IDX_RK4_X_DPOS:IDX_RK4_Z_DPOS) = parcels%delta_pos(:, n)
             buffer(IDX_RK4_X_DVOR:IDX_RK4_Z_DVOR) = parcels%delta_vor(:, n)
             buffer(IDX_RK4_DB11:IDX_RK4_DB23)     = parcels%delta_b(:, n)
             buffer(IDX_RK4_DUDX:IDX_RK4_DWDY)     = parcels%strain(:, n)
@@ -337,7 +337,7 @@ module parcel_container
             parcels%humidity(n)     = buffer(IDX_HUM)
 #endif
             ! LS-RK4 variables:
-            parcels%delta_pos(:, n) = buffer(IDX_RK4_X_DPOS:IDX_RK4_Z_DPOX)
+            parcels%delta_pos(:, n) = buffer(IDX_RK4_X_DPOS:IDX_RK4_Z_DPOS)
             parcels%delta_vor(:, n) = buffer(IDX_RK4_X_DVOR:IDX_RK4_Z_DVOR)
             parcels%delta_b(:, n)   = buffer(IDX_RK4_DB11:IDX_RK4_DB23)
             parcels%strain(:, n)    = buffer(IDX_RK4_DUDX:IDX_RK4_DWDY)

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -14,37 +14,37 @@ module parcel_container
     integer :: n_total_parcels  ! global number of parcels (over all MPI ranks)
 
     ! buffer indices to access individual parcel attributes
-    integer, protected :: IDX_X_POS         & ! x-position
-                          IDX_Y_POS         & ! y-position
-                          IDX_Z_POS         & ! z-position
-                          IDX_X_VOR         & ! x-vorticity
-                          IDX_Y_VOR         & ! y-vorticity
-                          IDX_Z_VOR         & ! z-vorticity
-                          IDX_B11           & ! B11 shape matrix element
-                          IDX_B12           & ! B12 shape matrix element
-                          IDX_B13           & ! B13 shape matrix element
-                          IDX_B22           & ! B22 shape matrix element
-                          IDX_B23           & ! B23 shape matrix element
-                          IDX_VOL           & ! volume
-                          IDX_BUO           & ! buoyancy
+    integer, protected :: IDX_X_POS,        & ! x-position
+                          IDX_Y_POS,        & ! y-position
+                          IDX_Z_POS,        & ! z-position
+                          IDX_X_VOR,        & ! x-vorticity
+                          IDX_Y_VOR,        & ! y-vorticity
+                          IDX_Z_VOR,        & ! z-vorticity
+                          IDX_B11,          & ! B11 shape matrix element
+                          IDX_B12,          & ! B12 shape matrix element
+                          IDX_B13,          & ! B13 shape matrix element
+                          IDX_B22,          & ! B22 shape matrix element
+                          IDX_B23,          & ! B23 shape matrix element
+                          IDX_VOL,          & ! volume
+                          IDX_BUO,          & ! buoyancy
 #ifndef ENABLE_DRY_MODE
-    integer, protected :: IDX_HUM           & ! humidity
+    integer, protected :: IDX_HUM,          & ! humidity
 #endif
-                          IDX_RK4_X_DPOS    & ! RK4 variable delta x-position
-                          IDX_RK4_Y_DPOS    & ! RK4 variable delta y-position
-                          IDX_RK4_Z_DPOX    & ! RK4 variable delta z-position
-                          IDX_RK4_X_DVOR    & ! RK4 variable delta x-vorticity
-                          IDX_RK4_Y_DVOR    & ! RK4 variable delta y-vorticity
-                          IDX_RK4_Z_DVOR    & ! RK4 variable delta z-vorticity
-                          IDX_RK4_DB11      & ! RK4 variable for B11
-                          IDX_RK4_DB12      & ! RK4 variable for B12
-                          IDX_RK4_DB13      & ! RK4 variable for B13
-                          IDX_RK4_DB22      & ! RK4 variable for B22
-                          IDX_RK4_DB23      & ! RK4 variable for B23
-                          IDX_RK4_DUDX      & ! RK4 variable du/dx
-                          IDX_RK4_DUDY      & ! RK4 variable du/dy
-                          IDX_RK4_DVDY      & ! RK4 variable dv/dy
-                          IDX_RK4_DWDX      & ! RK4 variable dw/dx
+                          IDX_RK4_X_DPOS,   & ! RK4 variable delta x-position
+                          IDX_RK4_Y_DPOS,   & ! RK4 variable delta y-position
+                          IDX_RK4_Z_DPOX,   & ! RK4 variable delta z-position
+                          IDX_RK4_X_DVOR,   & ! RK4 variable delta x-vorticity
+                          IDX_RK4_Y_DVOR,   & ! RK4 variable delta y-vorticity
+                          IDX_RK4_Z_DVOR,   & ! RK4 variable delta z-vorticity
+                          IDX_RK4_DB11,     & ! RK4 variable for B11
+                          IDX_RK4_DB12,     & ! RK4 variable for B12
+                          IDX_RK4_DB13,     & ! RK4 variable for B13
+                          IDX_RK4_DB22,     & ! RK4 variable for B22
+                          IDX_RK4_DB23,     & ! RK4 variable for B23
+                          IDX_RK4_DUDX,     & ! RK4 variable du/dx
+                          IDX_RK4_DUDY,     & ! RK4 variable du/dy
+                          IDX_RK4_DVDY,     & ! RK4 variable dv/dy
+                          IDX_RK4_DWDX,     & ! RK4 variable dw/dx
                           IDX_RK4_DWDY        ! RK4 variable dw/dy
 
     ! number of  parcel attributes

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -314,6 +314,11 @@ module parcel_container
 #ifndef ENABLE_DRY_MODE
             buffer(IDX_HUM)             = parcels%humidity(n)
 #endif
+            ! LS-RK4 variables:
+            buffer(IDX_RK4_X_DPOS:IDX_RK4_Z_DPOX) = parcels%delta_pos(:, n)
+            buffer(IDX_RK4_X_DVOR:IDX_RK4_Z_DVOR) = parcels%delta_vor(:, n)
+            buffer(IDX_RK4_DB11:IDX_RK4_DB23)     = parcels%delta_b(:, n)
+            buffer(IDX_RK4_DUDX:IDX_RK4_DWDY)     = parcels%strain(:, n)
         end subroutine parcel_serialize
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -331,6 +336,11 @@ module parcel_container
 #ifndef ENABLE_DRY_MODE
             parcels%humidity(n)     = buffer(IDX_HUM)
 #endif
+            ! LS-RK4 variables:
+            parcels%delta_pos(:, n) = buffer(IDX_RK4_X_DPOS:IDX_RK4_Z_DPOX)
+            parcels%delta_vor(:, n) = buffer(IDX_RK4_X_DVOR:IDX_RK4_Z_DVOR)
+            parcels%delta_b(:, n)   = buffer(IDX_RK4_DB11:IDX_RK4_DB23)
+            parcels%strain(:, n)    = buffer(IDX_RK4_DUDX:IDX_RK4_DWDY)
         end subroutine parcel_deserialize
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -226,16 +226,20 @@ module parcel_container
             endif
 #endif
 
-            parcels%position(:, n) = parcels%position(:, m)
-
+            parcels%position(:, n)  = parcels%position(:, m)
             parcels%vorticity(:, n) = parcels%vorticity(:, m)
-
-            parcels%volume(n)  = parcels%volume(m)
-            parcels%buoyancy(n) = parcels%buoyancy(m)
+            parcels%volume(n)       = parcels%volume(m)
+            parcels%buoyancy(n)     = parcels%buoyancy(m)
 #ifndef ENABLE_DRY_MODE
-            parcels%humidity(n) = parcels%humidity(m)
+            parcels%humidity(n)     = parcels%humidity(m)
 #endif
-            parcels%B(:, n) = parcels%B(:, m)
+            parcels%B(:, n)         = parcels%B(:, m)
+
+            ! LS-RK4 variables:
+            parcels%delta_pos(:, n) = parcels%delta_pos(:, m)
+            parcels%delta_vor(:, n) = parcels%delta_vor(:, m)
+            parcels%delta_b(:, n)   = parcels%delta_b(:, m)
+            parcels%strain(:, n)    = parcels%strain(:, m)
 
         end subroutine parcel_replace
 

--- a/src/3d/parcels/parcel_diagnostics.f90
+++ b/src/3d/parcels/parcel_diagnostics.f90
@@ -45,8 +45,7 @@ module parcel_diagnostics
     contains
 
         ! Calculate all parcel related diagnostics
-        subroutine calculate_parcel_diagnostics(velocity)
-            double precision, intent(in) :: velocity(:, :)
+        subroutine calculate_parcel_diagnostics
             integer          :: n
             double precision :: b, z, vel(3), vol, vor(3)
             double precision :: ntoti, bmin, bmax
@@ -67,7 +66,7 @@ module parcel_diagnostics
             !$omp& reduction(max: bmax) reduction(min: bmin)
             do n = 1, n_parcels
 
-                vel = velocity(:, n)
+                vel = parcels%delta_pos(:, n)
                 vor = parcels%vorticity(:, n)
                 vol = parcels%volume(n)
                 b   = parcels%buoyancy(n)

--- a/src/3d/parcels/parcel_nearest.f90
+++ b/src/3d/parcels/parcel_nearest.f90
@@ -1333,7 +1333,7 @@ module parcel_nearest
             integer                                    :: recv_size, send_size
             double precision                           :: buffer(n_par_attrib)
             integer                                    :: m, rc, ic, is, n, i, j, k, iv
-            integer                                    :: n_entries = n_par_attrib + 1
+            integer                                    :: n_entries
             integer                                    :: n_bytes
             integer, asynchronous                      :: n_parcel_recvs(8)
             type(MPI_Win)                              :: win_neighbour
@@ -1357,6 +1357,7 @@ module parcel_nearest
             !------------------------------------------------------------------
             ! We must send all parcel attributes (n_par_attrib) plus
             ! the index of the close parcel ic (1)
+            n_entries = n_par_attrib + 1
             n_registered = n_parcel_sends * n_entries
             call allocate_mpi_buffers(n_registered)
 

--- a/src/3d/parcels/parcel_nearest.f90
+++ b/src/3d/parcels/parcel_nearest.f90
@@ -1333,7 +1333,7 @@ module parcel_nearest
             integer                                    :: recv_size, send_size
             double precision                           :: buffer(n_par_attrib)
             integer                                    :: m, rc, ic, is, n, i, j, k, iv
-            integer, parameter                         :: n_entries = n_par_attrib + 1
+            integer                                    :: n_entries = n_par_attrib + 1
             integer                                    :: n_bytes
             integer, asynchronous                      :: n_parcel_recvs(8)
             type(MPI_Win)                              :: win_neighbour

--- a/src/3d/stepper/ls_rk4.f90
+++ b/src/3d/stepper/ls_rk4.f90
@@ -9,7 +9,7 @@ module ls_rk4
     use parcel_bc
     use rk4_utils, only: get_dBdt, get_time_step
     use utils, only : write_step
-    use parcel_interpl, only : par2grid, grid2par, grid2par_add
+    use parcel_interpl, only : par2grid, grid2par
     use fields, only : velgradg, velog, vortg, vtend, tbuoyg
     use inversion_mod, only : vor2vel, vorticity_tendency
     use parcel_diagnostics, only : calculate_parcel_diagnostics

--- a/src/3d/utils/utils.f90
+++ b/src/3d/utils/utils.f90
@@ -66,9 +66,6 @@ module utils
         ! @param[in] t is the time
         subroutine write_last_step(t)
             double precision,  intent(in) :: t
-            double precision              :: velocity(3, n_parcels)
-            double precision              :: strain(5, n_parcels)
-            double precision              :: vorticity(3, n_parcels)
 
             call par2grid
 
@@ -78,9 +75,9 @@ module utils
 
             call vorticity_tendency
 
-            call grid2par(velocity, vorticity, strain)
+            call grid2par
 
-            call calculate_parcel_diagnostics(velocity)
+            call calculate_parcel_diagnostics
             call calculate_field_diagnostics
 
             call write_step(t, .true.)

--- a/unit-tests/3d/test_mpi_parcel_diagnostics.f90
+++ b/unit-tests/3d/test_mpi_parcel_diagnostics.f90
@@ -17,7 +17,6 @@ program test_mpi_parcel_diagnostics
     integer, parameter            :: n_per_dim = 2
     integer                       :: ix, iy, iz, i, j, k, l, n_total
     double precision              :: im, corner(3), total_vol
-    double precision, allocatable :: velocity(:, :)
 
     call mpi_comm_initialise
 
@@ -42,8 +41,6 @@ program test_mpi_parcel_diagnostics
     n_parcels = n_per_dim ** 3 * nz * (box%hi(2)-box%lo(2)+1) * (box%hi(1)-box%lo(1)+1)
     n_total = n_per_dim ** 3 * nz * ny * nx
     call parcel_alloc(n_parcels)
-
-    allocate(velocity(3, n_parcels))
 
     im = one / dble(n_per_dim)
 
@@ -72,9 +69,9 @@ program test_mpi_parcel_diagnostics
     parcels%B(1, 1:n_parcels) = get_abc(parcels%volume(1:n_parcels)) ** f23
     parcels%B(4, 1:n_parcels) = parcels%B(1, 1:n_parcels)
     parcels%vorticity(:, 1:n_parcels) = f12
-    velocity(:, 1:n_parcels)  = f12
+    parcels%delta_pos(:, 1:n_parcels)  = f12
 
-    call calculate_parcel_diagnostics(velocity)
+    call calculate_parcel_diagnostics
 
     if (comm%rank == comm%master) then
         total_vol = dble(n_total) * parcels%volume(1)
@@ -89,8 +86,6 @@ program test_mpi_parcel_diagnostics
         passed = (passed .and. (dabs(parcel_stats(IDX_RMS_ETA) - f12) < 1.0e-15))
         passed = (passed .and. (dabs(parcel_stats(IDX_RMS_ZETA) - f12) < 1.0e-15))
     endif
-
-    deallocate(velocity)
 
     call mpi_comm_finalise
 


### PR DESCRIPTION
We need to communicate the RK4 variables along with the parcel attributes. It is best to make them part of the parcel container and use the existing parcel halo swap routine.