### PR TITLE
Explicit array bounds

### DIFF
--- a/models/3d/Makefile.am
+++ b/models/3d/Makefile.am
@@ -1,6 +1,7 @@
 AM_FCFLAGS = 				\
 	-I $(top_builddir)/src/3d/	\
 	-I $(top_builddir)/src/utils	\
+	-I $(top_builddir)/src/mpi	\
 	-I $(top_builddir)/src/netcdf
 
 AM_LDFLAGS = 						\
@@ -20,6 +21,7 @@ epic3d_models_SOURCES =		\
 
 epic3d_models_LDADD = 					\
 	$(top_builddir)/src/utils/libepic_utils.la	\
+	$(top_builddir)/src/mpi/libepic_mpi.la		\
 	$(top_builddir)/src/netcdf/libepic_netcdf.la
 
 clean-local:

--- a/models/3d/epic3d-models.f90
+++ b/models/3d/epic3d-models.f90
@@ -88,7 +88,7 @@ program epic3d_models
                     stop
             end select
 
-            call write_netcdf_axis_3d(ncid, dimids, lower, dx, box%ncells)
+            call write_netcdf_axis_3d(ncid, dimids, lower, dx, (/nx, ny, nz+1/))
 
             ! write time
             call write_netcdf_scalar(ncid, axids(4), zero, 1)

--- a/mpi-tests/Makefile.am
+++ b/mpi-tests/Makefile.am
@@ -26,12 +26,28 @@ libcombi_la_LIBADD = 					\
 	$(top_builddir)/src/netcdf/libepic_netcdf.la
 
 mpitests_PROGRAMS =			\
-	test_moving_parcels		\
+	test_parcel_moving_equidistant	\
+	test_parcel_moving_random	\
+	test_parcel_split_random	\
+	test_parcel_merge_random	\
+	test_parcel_split_merge		\
 	test_merging_parcels		\
 	test_merging_parcels_serial
 
-test_moving_parcels_SOURCES = test_utils.f90 test_moving_parcels.f90
-test_moving_parcels_LDADD = libcombi.la
+test_parcel_moving_equidistant_SOURCES = test_utils.f90 test_parcel_moving_equidistant.f90
+test_parcel_moving_equidistant_LDADD = libcombi.la
+
+test_parcel_moving_random_SOURCES = test_utils.f90 test_parcel_moving_random.f90
+test_parcel_moving_random_LDADD = libcombi.la
+
+test_parcel_split_random_SOURCES = test_utils.f90 test_parcel_split_random.f90
+test_parcel_split_random_LDADD = libcombi.la
+
+test_parcel_merge_random_SOURCES = test_utils.f90 test_parcel_merge_random.f90
+test_parcel_merge_random_LDADD = libcombi.la
+
+test_parcel_split_merge_SOURCES = test_utils.f90 test_parcel_split_merge.f90
+test_parcel_split_merge_LDADD = libcombi.la
 
 test_merging_parcels_SOURCES = test_utils.f90 test_merging_parcels.f90
 test_merging_parcels_LDADD = libcombi.la

--- a/mpi-tests/test_merging_parcels.f90
+++ b/mpi-tests/test_merging_parcels.f90
@@ -14,18 +14,19 @@ program test_merging_parcels
 
     call register_all_timers
 
-    nx = 10
-    ny = 10
-    nz = 10
+    nx = 32
+    ny = 32
+    nz = 32
     lower  = (/zero, zero, zero/)
     extent = (/one, one, one/)
 
     parcel%lambda_max = 4.0d0
     parcel%min_vratio = 40.0d0
-
-    call update_parameters
+    parcel%size_factor = 4
 
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/mpi-tests/test_merging_parcels_serial.f90
+++ b/mpi-tests/test_merging_parcels_serial.f90
@@ -8,6 +8,7 @@ program test_merging_parcels
     use mpi_communicator
     use mpi_layout
     use mpi_utils, only : mpi_exit_on_error
+    use mpi_layout, only : mpi_layout_init
     use test_utils
     implicit none
 
@@ -19,18 +20,19 @@ program test_merging_parcels
 
     call register_all_timers
 
-    nx = 10
-    ny = 10
-    nz = 10
+    nx = 32
+    ny = 32
+    nz = 32
     lower  = (/zero, zero, zero/)
     extent = (/one, one, one/)
 
     parcel%lambda_max = 4.0d0
     parcel%min_vratio = 40.0d0
-
-    call update_parameters
+    parcel%size_factor = 4
 
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/mpi-tests/test_parcel_merge_random.f90
+++ b/mpi-tests/test_parcel_merge_random.f90
@@ -1,0 +1,193 @@
+program test_parcel_merge_random
+    use mpi_communicator
+    use options, only : parcel
+    use constants, only : zero, one, two
+    use parameters, only : update_parameters, nx, ny, nz, lower, extent, vmin
+    use parcel_container
+    use parcel_init, only : parcel_default
+    use parcel_mpi, only : parcel_communicate
+    use fields, only : field_default
+    use parcel_bc, only : apply_periodic_bc
+    use parcel_interpl, only : par2grid
+    use parcel_merge, only : merge_parcels
+    use parcel_nearest
+    use mpi_layout, only : box, mpi_layout_init
+    use test_utils
+    implicit none
+
+    integer, parameter   :: nt = 100
+    integer              :: i, n, sk, j, n_orig, n_merges
+    integer, allocatable :: seed(:)
+    double precision     :: rn(3)
+    double precision     :: vol, b(5)
+
+    !--------------------------------------------------------------------------
+    ! Initialise MPI and setup all timers:
+
+    call mpi_comm_initialise
+
+    if (comm%rank == comm%master) then
+        print '(a35, i6, a11)', "Running 'test_parcel_merge_random' with ", comm%size, " MPI ranks."
+    endif
+
+    call random_seed(size=sk)
+    allocate(seed(1:sk))
+    seed(:) = comm%rank
+    call random_seed(put=seed)
+
+
+    call register_all_timers
+
+    call start_timer(epic_timer)
+
+    !--------------------------------------------------------------------------
+    ! Set model parameters:
+
+    nx = 128
+    ny = 128
+    nz = 64
+    lower = (/zero, zero, zero/)
+    extent = (/two, two, one/)
+
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
+
+    parcel%n_per_cell = 8
+
+    call nearest_win_allocate
+
+    !--------------------------------------------------------------------------
+    ! Setup fields: All fields are zero
+
+    call field_default
+
+    !--------------------------------------------------------------------------
+    ! Setup parcels:
+
+    call parcel_default
+
+    vol = parcels%volume(1)
+    b = parcels%B(:, 1)
+
+    !--------------------------------------------------------------------------
+    ! Check initial values:
+    call perform_checks
+
+    !--------------------------------------------------------------------------
+    ! Do time loop:
+    do i = 1, nt
+
+        if (comm%rank == comm%master) then
+            print '(a15, i4)', "Performing step", i
+        endif
+
+        ! Move each parcel by random value in x and y
+        do n = 1, n_parcels
+            call random_number(rn)
+
+            if (rn(3) > 0.5d0) then
+                call random_number(rn(3))
+                j = nint(n_parcels * rn(3)) + 1
+                parcels%volume(j) = 0.9d0 * vmin
+                parcels%buoyancy(j) = 1.0d0
+            endif
+
+        enddo
+
+        n_merges = int(sum(parcels%buoyancy(1:n_parcels)))
+        call perform_integer_reduction(n_merges)
+
+        if (comm%rank == comm%master) then
+            print *, "Merge", n_merges, "of", n_total_parcels, "parcels."
+        endif
+
+        n_orig = n_parcels
+
+        ! Merge parcels
+        call merge_parcels(parcels)
+
+        ! Interpolate parcel data to grid
+        call par2grid
+
+        ! Test number of parcels: etc.
+        call perform_checks
+
+        ! Reset:
+        n_parcels = n_orig
+        do n = 1, n_parcels
+            parcels%volume(n) = vol
+            parcels%buoyancy(n) = 0.0d0
+            parcels%B(:, n) = b
+
+            call random_number(rn)
+            parcels%position(:, n) = box%lower + box%extent * rn
+        enddo
+
+        call perform_integer_reduction(n_orig)
+        n_total_parcels = n_orig
+
+        ! Do halo swap
+        call parcel_communicate
+
+        ! Do periodic shift in x and y
+        do n = 1, n_parcels
+            call apply_periodic_bc(parcels%position(:, n))
+        enddo
+    enddo
+
+    !--------------------------------------------------------------------------
+    ! Finish: Free memory and finalise MPI
+
+    call parcel_dealloc
+
+    call nearest_win_deallocate
+
+    call stop_timer(epic_timer)
+
+    call print_timer
+
+    call mpi_comm_finalise
+
+
+    contains
+
+        subroutine perform_checks
+            call check_total_number_of_parcels
+
+        end subroutine perform_checks
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine check_total_number_of_parcels
+            integer :: n_total
+
+            n_total = n_parcels
+
+            call perform_integer_reduction(n_total)
+
+            if (comm%rank == comm%master) then
+                if (n_total /= n_total_parcels) then
+                    print *, "check_total_number_of_parcels: Total number of parcels disagree!"
+                    call MPI_Abort(comm%world, -1, comm%err)
+                endif
+            endif
+
+        end subroutine check_total_number_of_parcels
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine perform_integer_reduction(var)
+            integer, intent(inout) :: var
+
+            if (comm%rank == comm%master) then
+                call MPI_Reduce(MPI_IN_PLACE, var, 1, MPI_INTEGER, MPI_SUM, &
+                                comm%master, comm%world, comm%err)
+            else
+                call MPI_Reduce(var, var, 1, MPI_INTEGER, MPI_SUM, &
+                                comm%master, comm%world, comm%err)
+            endif
+
+        end subroutine perform_integer_reduction
+
+end program test_parcel_merge_random

--- a/mpi-tests/test_parcel_moving_equidistant.f90
+++ b/mpi-tests/test_parcel_moving_equidistant.f90
@@ -1,0 +1,195 @@
+program test_parcel_moving_equidistant
+    use mpi_communicator
+    use options, only : parcel
+    use constants, only : zero, one, two
+    use parameters, only : update_parameters, nx, ny, nz, lower, extent, dx
+    use parcel_container
+    use parcel_init, only : parcel_default
+    use parcel_mpi, only : parcel_communicate
+    use fields, only : field_default, nparg, vortg
+    use parcel_bc, only : apply_periodic_bc
+    use mpi_layout, only : box, mpi_layout_init
+    use parcel_interpl, only : par2grid
+    use test_utils
+    implicit none
+
+    integer, parameter :: nt = 100
+    integer            :: i, n
+    double precision   :: VOR(3) = (/1.5d0, 2.0d0, 2.5d0/)
+
+    !--------------------------------------------------------------------------
+    ! Initialise MPI and setup all timers:
+
+    call mpi_comm_initialise
+
+    if (comm%rank == comm%master) then
+        print '(a35, i6, a11)', "Running 'test_parcel_moving_equidistant' with ", comm%size, " MPI ranks."
+    endif
+
+    call register_all_timers
+
+    call start_timer(epic_timer)
+
+    !--------------------------------------------------------------------------
+    ! Set model parameters:
+
+    nx = 128
+    ny = 128
+    nz = 64
+    lower = (/zero, zero, zero/)
+    extent = (/two, two, one/)
+
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
+
+    parcel%n_per_cell = 8
+
+    !--------------------------------------------------------------------------
+    ! Setup fields: All fields are zero
+
+    call field_default
+
+    !--------------------------------------------------------------------------
+    ! Setup parcels:
+
+    call parcel_default
+
+    do i = 1, 3
+        parcels%vorticity(i, 1:n_parcels) = VOR(i)
+    enddo
+
+    !--------------------------------------------------------------------------
+    ! Interpolate parcel data to grid:
+    call par2grid
+
+    !--------------------------------------------------------------------------
+    ! Check initial values:
+    call perform_checks
+
+    !--------------------------------------------------------------------------
+    ! Do time loop:
+
+    do i = 1, nt
+
+        if (comm%rank == comm%master) then
+            print '(a15, i4)', "Performing step", i
+        endif
+
+        VOR = 1.00d0 * VOR
+
+        ! Move each parcel by dx and dy
+        do n = 1, n_parcels
+            parcels%position(1:2, n) = parcels%position(1:2, n) + dx(1:2)
+            parcels%vorticity(:, n) = VOR
+        enddo
+
+        ! Do halo swap
+        call parcel_communicate
+
+        ! Do periodic shift in x and y
+        do n = 1, n_parcels
+            call apply_periodic_bc(parcels%position(:, n))
+        enddo
+
+        ! Interpolate parcel data to grid
+        call par2grid
+
+        ! Test number of parcels: etc.
+        call perform_checks
+    enddo
+
+    !--------------------------------------------------------------------------
+    ! Finish: Free memory and finalise MPI
+
+    call parcel_dealloc
+
+    call stop_timer(epic_timer)
+
+    call print_timer
+
+    call mpi_comm_finalise
+
+
+    contains
+
+        subroutine perform_checks
+            call check_total_number_of_parcels
+
+            call check_number_of_parcels_per_cell
+
+            call check_gridded_vorticity
+
+        end subroutine perform_checks
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine check_total_number_of_parcels
+            integer :: n_total
+
+            n_total = n_parcels
+
+            call perform_integer_reduction(n_total)
+
+            if (comm%rank == comm%master) then
+                if (n_total /= n_total_parcels) then
+                    print *, "check_total_number_of_parcels: Total number of parcels disagree!"
+                    call MPI_Abort(comm%world, -1, comm%err)
+                endif
+            endif
+
+        end subroutine check_total_number_of_parcels
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine check_number_of_parcels_per_cell
+            integer :: n_total
+
+            n_total = sum(nparg(0:nz, box%lo(2):box%hi(2), box%lo(1):box%hi(1)))
+
+            call perform_integer_reduction(n_total)
+
+            if (comm%rank == comm%master) then
+                if (n_total /= n_total_parcels) then
+                    print *, "check_number_of_parcels_per_cell: Total number of parcel disagrees with grid!"
+                    call MPI_Abort(comm%world, -1, comm%err)
+                endif
+            endif
+
+        end subroutine check_number_of_parcels_per_cell
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine check_gridded_vorticity
+            double precision :: vmin, vmax
+            integer          :: j
+            character(1)     :: dir(3) = (/'x', 'y', 'z'/)
+
+            do j = 1, 3
+                vmin = minval(vortg(0:nz, :, :, j))
+                vmax = maxval(vortg(0:nz, :, :, j))
+
+                if ((dabs(vmin - VOR(j)) > 100.0d0 * epsilon(vmin)) .or. &
+                    (dabs(vmax - VOR(j)) > 100.0d0 * epsilon(vmax))) then
+                    print *, "check_gridded_vorticity: Error in " // dir(j) // "-vorticity!"
+                    call MPI_Abort(comm%world, -1, comm%err)
+                endif
+            enddo
+        end subroutine check_gridded_vorticity
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine perform_integer_reduction(var)
+            integer, intent(inout) :: var
+
+            if (comm%rank == comm%master) then
+                call MPI_Reduce(MPI_IN_PLACE, var, 1, MPI_INTEGER, MPI_SUM, &
+                                comm%master, comm%world, comm%err)
+            else
+                call MPI_Reduce(var, var, 1, MPI_INTEGER, MPI_SUM, &
+                                comm%master, comm%world, comm%err)
+            endif
+
+        end subroutine perform_integer_reduction
+
+end program test_parcel_moving_equidistant

--- a/mpi-tests/test_parcel_moving_random.f90
+++ b/mpi-tests/test_parcel_moving_random.f90
@@ -1,21 +1,22 @@
-program test_moving_parcels
+program test_parcel_moving_random
     use mpi_communicator
     use options, only : parcel
     use constants, only : zero, one, two
     use parameters, only : update_parameters, nx, ny, nz, lower, extent, dx
     use parcel_container
     use parcel_init, only : parcel_default
-    use parcel_mpi, only : parcel_halo_swap
-    use fields, only : field_default, nparg, vortg
+    use parcel_mpi, only : parcel_communicate
+    use fields, only : field_default
     use parcel_bc, only : apply_periodic_bc
-    use mpi_layout, only : box
     use parcel_interpl, only : par2grid
+    use mpi_layout, only : mpi_layout_init
     use test_utils
     implicit none
 
-    integer, parameter :: nt = 100
-    integer            :: i, n
-    double precision   :: VOR(3) = (/1.5d0, 2.0d0, 2.5d0/)
+    integer, parameter   :: nt = 100
+    integer              :: i, n, sk
+    integer, allocatable :: seed(:)
+    double precision     :: rn(2)
 
     !--------------------------------------------------------------------------
     ! Initialise MPI and setup all timers:
@@ -23,8 +24,14 @@ program test_moving_parcels
     call mpi_comm_initialise
 
     if (comm%rank == comm%master) then
-        print '(a35, i6, a11)', "Running test 'moving parcels' with ", comm%size, " MPI ranks."
+        print '(a35, i6, a11)', "Running 'test_parcel_moving_random' with ", comm%size, " MPI ranks."
     endif
+
+    call random_seed(size=sk)
+    allocate(seed(1:sk))
+    seed(:) = comm%rank
+    call random_seed(put=seed)
+
 
     call register_all_timers
 
@@ -39,6 +46,8 @@ program test_moving_parcels
     lower = (/zero, zero, zero/)
     extent = (/two, two, one/)
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
     parcel%n_per_cell = 8
@@ -52,10 +61,6 @@ program test_moving_parcels
     ! Setup parcels:
 
     call parcel_default
-
-    do i = 1, 3
-        parcels%vorticity(i, 1:n_parcels) = VOR(i)
-    enddo
 
     !--------------------------------------------------------------------------
     ! Interpolate parcel data to grid:
@@ -74,16 +79,14 @@ program test_moving_parcels
             print '(a15, i4)', "Performing step", i
         endif
 
-        VOR = 1.00d0 * VOR
-
-        ! Move each parcel by dx and dy
+        ! Move each parcel by random value in x and y
         do n = 1, n_parcels
-            parcels%position(1:2, n) = parcels%position(1:2, n) + dx(1:2)
-            parcels%vorticity(:, n) = VOR
+            call random_number(rn)
+            parcels%position(1:2, n) = parcels%position(1:2, n) + rn * dx(1:2)
         enddo
 
         ! Do halo swap
-        call parcel_halo_swap
+        call parcel_communicate
 
         ! Do periodic shift in x and y
         do n = 1, n_parcels
@@ -114,10 +117,6 @@ program test_moving_parcels
         subroutine perform_checks
             call check_total_number_of_parcels
 
-            call check_number_of_parcels_per_cell
-
-            call check_gridded_vorticity
-
         end subroutine perform_checks
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -140,43 +139,6 @@ program test_moving_parcels
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-        subroutine check_number_of_parcels_per_cell
-            integer :: n_total
-
-            n_total = sum(nparg(0:nz, box%lo(2):box%hi(2), box%lo(1):box%hi(1)))
-
-            call perform_integer_reduction(n_total)
-
-            if (comm%rank == comm%master) then
-                if (n_total /= n_total_parcels) then
-                    print *, "check_number_of_parcels_per_cell: Total number of parcel disagrees with grid!"
-                    call MPI_Abort(comm%world, -1, comm%err)
-                endif
-            endif
-
-        end subroutine check_number_of_parcels_per_cell
-
-        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-
-        subroutine check_gridded_vorticity
-            double precision :: vmin, vmax
-            integer          :: j
-            character(1)     :: dir(3) = (/'x', 'y', 'z'/)
-
-            do j = 1, 3
-                vmin = minval(vortg(0:nz, :, :, j))
-                vmax = maxval(vortg(0:nz, :, :, j))
-
-                if ((dabs(vmin - VOR(j)) > 100.0d0 * epsilon(vmin)) .or. &
-                    (dabs(vmax - VOR(j)) > 100.0d0 * epsilon(vmax))) then
-                    print *, "check_gridded_vorticity: Error in " // dir(j) // "-vorticity!"
-                    call MPI_Abort(comm%world, -1, comm%err)
-                endif
-            enddo
-        end subroutine check_gridded_vorticity
-
-        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-
         subroutine perform_integer_reduction(var)
             integer, intent(inout) :: var
 
@@ -190,4 +152,4 @@ program test_moving_parcels
 
         end subroutine perform_integer_reduction
 
-end program test_moving_parcels
+end program test_parcel_moving_random

--- a/mpi-tests/test_parcel_split_merge.f90
+++ b/mpi-tests/test_parcel_split_merge.f90
@@ -1,0 +1,176 @@
+program test_parcel_spli_merge
+    use mpi_communicator
+    use options, only : parcel
+    use constants, only : zero, one, two
+    use parameters, only : update_parameters, nx, ny, nz, lower, extent, vmin, dx
+    use parcel_container
+    use parcel_init, only : parcel_default
+    use parcel_mpi, only : parcel_communicate
+    use fields, only : field_default
+    use parcel_bc, only : apply_periodic_bc, apply_parcel_bc
+    use parcel_interpl, only : par2grid
+    use parcel_split_mod, only : parcel_split
+    use parcel_merge, only : merge_parcels
+    use parcel_nearest
+    use mpi_layout, only : mpi_layout_init
+    use test_utils
+    implicit none
+
+    integer, parameter   :: nt = 100
+    integer              :: i, n, sk, n_orig, n_merges
+    integer, allocatable :: seed(:)
+    double precision     :: rn(3)
+
+    !--------------------------------------------------------------------------
+    ! Initialise MPI and setup all timers:
+
+    call mpi_comm_initialise
+
+    if (comm%rank == comm%master) then
+        print '(a35, i6, a11)', "Running 'test_parcel_spli_merge' with ", comm%size, " MPI ranks."
+    endif
+
+    call random_seed(size=sk)
+    allocate(seed(1:sk))
+    seed(:) = comm%rank
+    call random_seed(put=seed)
+
+
+    call register_all_timers
+
+    call start_timer(epic_timer)
+
+    !--------------------------------------------------------------------------
+    ! Set model parameters:
+
+    nx = 128
+    ny = 128
+    nz = 64
+    lower = (/zero, zero, zero/)
+    extent = (/two, two, one/)
+
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
+
+    parcel%n_per_cell = 8
+
+    call nearest_win_allocate
+
+    !--------------------------------------------------------------------------
+    ! Setup fields: All fields are zero
+
+    call field_default
+
+    !--------------------------------------------------------------------------
+    ! Setup parcels:
+
+    call parcel_default
+
+    !--------------------------------------------------------------------------
+    ! Check initial values:
+    call perform_checks
+
+    !--------------------------------------------------------------------------
+    ! Do time loop:
+    do i = 1, nt
+
+        if (comm%rank == comm%master) then
+            print '(a15, i4)', "Performing step", i
+        endif
+
+        ! Move each parcel by random value in x and y
+        do n = 1, n_parcels
+            call random_number(rn)
+            parcels%position(1:2, n) = parcels%position(1:2, n) + rn(1:2) * dx(1:2)
+        enddo
+
+        call parcel_communicate
+
+        call apply_parcel_bc
+
+        n_merges = count(parcels%volume(1:n_parcels) < vmin)
+        call perform_integer_reduction(n_merges)
+
+        if (comm%rank == comm%master) then
+            print *, "Merge", n_merges, "of", n_total_parcels, "parcels."
+        endif
+
+        call merge_parcels(parcels)
+
+        do n = 1, n_parcels
+            call random_number(rn)
+            parcels%B(1, n) = (1.0d0 + rn(1) * 0.3d0) * parcels%B(1, n)
+            parcels%B(3, n) = (1.0d0 - rn(2) * 0.3d0) * parcels%B(3, n)
+        enddo
+
+        ! Split parcels
+        n_orig = n_total_parcels
+        call parcel_split(parcels, 4.0d0)
+
+        if (comm%rank == comm%master) then
+            print *, "Split", n_total_parcels - n_orig, "of", n_total_parcels, "parcels."
+        endif
+
+        ! Interpolate parcel data to grid
+        call par2grid
+
+        ! Test number of parcels: etc.
+        call perform_checks
+    enddo
+
+    !--------------------------------------------------------------------------
+    ! Finish: Free memory and finalise MPI
+
+    call parcel_dealloc
+
+    call nearest_win_deallocate
+
+    call stop_timer(epic_timer)
+
+    call print_timer
+
+    call mpi_comm_finalise
+
+
+    contains
+
+        subroutine perform_checks
+            call check_total_number_of_parcels
+
+        end subroutine perform_checks
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine check_total_number_of_parcels
+            integer :: n_total
+
+            n_total = n_parcels
+
+            call perform_integer_reduction(n_total)
+
+            if (comm%rank == comm%master) then
+                if (n_total /= n_total_parcels) then
+                    print *, "check_total_number_of_parcels: Total number of parcels disagree!"
+                    call MPI_Abort(comm%world, -1, comm%err)
+                endif
+            endif
+
+        end subroutine check_total_number_of_parcels
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine perform_integer_reduction(var)
+            integer, intent(inout) :: var
+
+            if (comm%rank == comm%master) then
+                call MPI_Reduce(MPI_IN_PLACE, var, 1, MPI_INTEGER, MPI_SUM, &
+                                comm%master, comm%world, comm%err)
+            else
+                call MPI_Reduce(var, var, 1, MPI_INTEGER, MPI_SUM, &
+                                comm%master, comm%world, comm%err)
+            endif
+
+        end subroutine perform_integer_reduction
+
+end program test_parcel_spli_merge

--- a/mpi-tests/test_parcel_split_random.f90
+++ b/mpi-tests/test_parcel_split_random.f90
@@ -1,0 +1,188 @@
+program test_parcel_split_random
+    use mpi_communicator
+    use options, only : parcel
+    use constants, only : zero, one, two
+    use parameters, only : update_parameters, nx, ny, nz, lower, extent, vmax
+    use parcel_container
+    use parcel_init, only : parcel_default
+    use parcel_mpi, only : parcel_communicate
+    use fields, only : field_default
+    use parcel_bc, only : apply_periodic_bc
+    use parcel_interpl, only : par2grid
+    use parcel_split_mod, only : parcel_split
+    use mpi_layout, only : box, mpi_layout_init
+    use test_utils
+    implicit none
+
+    integer, parameter   :: nt = 100
+    integer              :: i, n, sk, j, n_orig, n_splits
+    integer, allocatable :: seed(:)
+    double precision     :: rn(3)
+    double precision     :: vol, b(5)
+
+    !--------------------------------------------------------------------------
+    ! Initialise MPI and setup all timers:
+
+    call mpi_comm_initialise
+
+    if (comm%rank == comm%master) then
+        print '(a35, i6, a11)', "Running 'test_parcel_split_random' with ", comm%size, " MPI ranks."
+    endif
+
+    call random_seed(size=sk)
+    allocate(seed(1:sk))
+    seed(:) = comm%rank
+    call random_seed(put=seed)
+
+
+    call register_all_timers
+
+    call start_timer(epic_timer)
+
+    !--------------------------------------------------------------------------
+    ! Set model parameters:
+
+    nx = 128
+    ny = 128
+    nz = 64
+    lower = (/zero, zero, zero/)
+    extent = (/two, two, one/)
+
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
+
+    parcel%n_per_cell = 8
+
+    !--------------------------------------------------------------------------
+    ! Setup fields: All fields are zero
+
+    call field_default
+
+    !--------------------------------------------------------------------------
+    ! Setup parcels:
+
+    call parcel_default
+
+    vol = parcels%volume(1)
+    b = parcels%B(:, 1)
+
+    !--------------------------------------------------------------------------
+    ! Check initial values:
+    call perform_checks
+
+    !--------------------------------------------------------------------------
+    ! Do time loop:
+    do i = 1, nt
+
+        if (comm%rank == comm%master) then
+            print '(a15, i4)', "Performing step", i
+        endif
+
+        ! Move each parcel by random value in x and y
+        do n = 1, n_parcels
+            call random_number(rn)
+
+            if (rn(3) > 0.5d0) then
+                call random_number(rn(3))
+                j = nint(n_parcels * rn(3)) + 1
+                parcels%volume(j) = 1.1d0 * vmax
+                parcels%buoyancy(j) = 1.0d0
+            endif
+
+        enddo
+
+        n_splits = int(sum(parcels%buoyancy(1:n_parcels)))
+        call perform_integer_reduction(n_splits)
+
+        if (comm%rank == comm%master) then
+            print *, "Split", n_splits, "of", n_total_parcels, "parcels."
+        endif
+
+        n_orig = n_parcels
+
+        ! Split parcels
+        call parcel_split(parcels, 4.0d0)
+
+        ! Interpolate parcel data to grid
+        call par2grid
+
+        ! Test number of parcels: etc.
+        call perform_checks
+
+        ! Reset:
+        n_parcels = n_orig
+        do n = 1, n_parcels
+            parcels%volume(n) = vol
+            parcels%buoyancy(n) = 0.0d0
+            parcels%B(:, n) = b
+
+            call random_number(rn)
+            parcels%position(:, n) = box%lower + box%extent * rn
+        enddo
+
+        call perform_integer_reduction(n_orig)
+        n_total_parcels = n_orig
+
+        ! Do halo swap
+        call parcel_communicate
+
+        ! Do periodic shift in x and y
+        do n = 1, n_parcels
+            call apply_periodic_bc(parcels%position(:, n))
+        enddo
+    enddo
+
+    !--------------------------------------------------------------------------
+    ! Finish: Free memory and finalise MPI
+
+    call parcel_dealloc
+
+    call stop_timer(epic_timer)
+
+    call print_timer
+
+    call mpi_comm_finalise
+
+
+    contains
+
+        subroutine perform_checks
+            call check_total_number_of_parcels
+
+        end subroutine perform_checks
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine check_total_number_of_parcels
+            integer :: n_total
+
+            n_total = n_parcels
+
+            call perform_integer_reduction(n_total)
+
+            if (comm%rank == comm%master) then
+                if (n_total /= n_total_parcels) then
+                    print *, "check_total_number_of_parcels: Total number of parcels disagree!"
+                    call MPI_Abort(comm%world, -1, comm%err)
+                endif
+            endif
+
+        end subroutine check_total_number_of_parcels
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine perform_integer_reduction(var)
+            integer, intent(inout) :: var
+
+            if (comm%rank == comm%master) then
+                call MPI_Reduce(MPI_IN_PLACE, var, 1, MPI_INTEGER, MPI_SUM, &
+                                comm%master, comm%world, comm%err)
+            else
+                call MPI_Reduce(var, var, 1, MPI_INTEGER, MPI_SUM, &
+                                comm%master, comm%world, comm%err)
+            endif
+
+        end subroutine perform_integer_reduction
+
+end program test_parcel_split_random

--- a/src/3d/Makefile.am
+++ b/src/3d/Makefile.am
@@ -1,8 +1,8 @@
 if ENABLE_3D
 AM_FCFLAGS =				\
+	-I $(top_builddir)/src/mpi	\
 	-I $(top_builddir)/src/utils	\
 	-I $(top_builddir)/src/fft	\
-	-I $(top_builddir)/src/mpi	\
 	-I $(top_builddir)/src/netcdf
 
 bin_PROGRAMS = epic3d

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -8,7 +8,8 @@ program epic3d
     use parcel_bc
     use parcel_split_mod, only : parcel_split, split_timer
     use parcel_merge, only : merge_parcels, merge_timer
-    use parcel_nearest, only : merge_nearest_timer, merge_tree_resolve_timer
+    use parcel_nearest, only : merge_nearest_timer, merge_tree_resolve_timer, &
+    nearest_win_allocate, nearest_win_deallocate
     use parcel_correction, only : apply_laplace,          &
                                   apply_gradient,         &
                                   apply_vortcor,          &
@@ -97,6 +98,8 @@ program epic3d
 
             call setup_output_files
 
+            call nearest_win_allocate
+
         end subroutine
 
 
@@ -143,6 +146,7 @@ program epic3d
         subroutine post_run
             use options, only : output
             call parcel_dealloc
+            call nearest_win_deallocate
             call finalise_pencil_fft
             call stop_timer(epic_timer)
 

--- a/src/3d/fields/field_diagnostics_netcdf.f90
+++ b/src/3d/fields/field_diagnostics_netcdf.f90
@@ -59,11 +59,16 @@ module field_diagnostics_netcdf
             if (l_restart .and. l_exist) then
                 call open_netcdf_file(ncfname, NF90_NOWRITE, ncid, l_serial=.true.)
                 call get_num_steps(ncid, n_writes)
-                call get_time(ncid, restart_time)
-                call read_netcdf_field_stats_content
-                call close_netcdf_file(ncid, l_serial=.true.)
-                n_writes = n_writes + 1
-                return
+                if (n_writes > 0) then
+                    call get_time(ncid, restart_time)
+                    call read_netcdf_field_stats_content
+                    call close_netcdf_file(ncid, l_serial=.true.)
+                    n_writes = n_writes + 1
+                    return
+                else
+                    call close_netcdf_file(ncid, l_serial=.true.)
+                    call delete_netcdf_file(ncfname)
+                endif
             endif
 
             call create_netcdf_file(ncfname, overwrite, ncid, l_serial=.true.)

--- a/src/3d/fields/field_mpi.f90
+++ b/src/3d/fields/field_mpi.f90
@@ -102,7 +102,7 @@ module field_mpi
             double precision, dimension(:), pointer :: send_buf, recv_buf
             type(MPI_Request)                       :: requests(8)
             type(MPI_Status)                        :: statuses(8)
-            integer                                 :: tag, n
+            integer                                 :: tag, n, lb, ub
 
             do n = 1, 8
 
@@ -110,7 +110,10 @@ module field_mpi
 
                 call get_interior_buffer_ptr(tag, recv_buf)
 
-                call MPI_Irecv(recv_buf,                &
+                lb = lbound(recv_buf)
+                ub = ubound(recv_buf)
+
+                call MPI_Irecv(recv_buf(lb:ub),         &
                                size(recv_buf),          &
                                MPI_DOUBLE_PRECISION,    &
                                neighbours(tag)%rank,    &
@@ -126,7 +129,10 @@ module field_mpi
 
                 call get_halo_buffer_ptr(n, send_buf)
 
-                call MPI_Send(send_buf,                &
+                lb = lbound(send_buf)
+                ub = ubound(send_buf)
+
+                call MPI_Send(send_buf(lb:ub),         &
                               size(send_buf),          &
                               MPI_DOUBLE_PRECISION,    &
                               neighbours(n)%rank,      &
@@ -152,7 +158,7 @@ module field_mpi
             double precision, dimension(:), pointer :: send_buf, recv_buf
             type(MPI_Request)                       :: requests(8)
             type(MPI_Status)                        :: statuses(8)
-            integer                                 :: tag, n
+            integer                                 :: tag, n, lb, ub
 
             do n = 1, 8
 
@@ -160,7 +166,10 @@ module field_mpi
 
                 call get_halo_buffer_ptr(tag, recv_buf)
 
-                call MPI_Irecv(recv_buf,                &
+                lb = lbound(recv_buf)
+                ub = ubound(recv_buf)
+
+                call MPI_Irecv(recv_buf(lb:ub),         &
                                size(recv_buf),          &
                                MPI_DOUBLE_PRECISION,    &
                                neighbours(tag)%rank,    &
@@ -176,7 +185,10 @@ module field_mpi
             do n = 1, 8
                 call get_interior_buffer_ptr(n, send_buf)
 
-                call MPI_Send(send_buf,                &
+                lb = lbound(send_buf)
+                ub = ubound(send_buf)
+
+                call MPI_Send(send_buf(lb:ub),         &
                               size(send_buf),          &
                               MPI_DOUBLE_PRECISION,    &
                               neighbours(n)%rank,      &

--- a/src/3d/fields/field_mpi.f90
+++ b/src/3d/fields/field_mpi.f90
@@ -106,7 +106,7 @@ module field_mpi
 
             do n = 1, 8
 
-                tag = NEIGHBOUR_TAG(n)
+                tag = RECV_NEIGHBOUR_TAG(n)
 
                 call get_interior_buffer_ptr(tag, recv_buf)
 
@@ -115,7 +115,7 @@ module field_mpi
                 call MPI_Irecv(recv_buf(1:recv_size),   &
                                recv_size,               &
                                MPI_DOUBLE_PRECISION,    &
-                               neighbours(tag)%rank,    &
+                               neighbours(n)%rank,      &
                                tag,                     &
                                comm%cart,               &
                                requests(n),             &
@@ -134,7 +134,7 @@ module field_mpi
                               send_size,                &
                               MPI_DOUBLE_PRECISION,     &
                               neighbours(n)%rank,       &
-                              NEIGHBOUR_TAG(n),         &
+                              SEND_NEIGHBOUR_TAG(n),    &
                               comm%cart,                &
                               comm%err)
 
@@ -160,7 +160,7 @@ module field_mpi
 
             do n = 1, 8
 
-                tag = NEIGHBOUR_TAG(n)
+                tag = RECV_NEIGHBOUR_TAG(n)
 
                 call get_halo_buffer_ptr(tag, recv_buf)
 
@@ -169,7 +169,7 @@ module field_mpi
                 call MPI_Irecv(recv_buf(1:recv_size),   &
                                recv_size,               &
                                MPI_DOUBLE_PRECISION,    &
-                               neighbours(tag)%rank,    &
+                               neighbours(n)%rank,      &
                                tag,                     &
                                comm%cart,               &
                                requests(n),             &
@@ -188,7 +188,7 @@ module field_mpi
                               send_size,                &
                               MPI_DOUBLE_PRECISION,     &
                               neighbours(n)%rank,       &
-                              NEIGHBOUR_TAG(n),         &
+                              SEND_NEIGHBOUR_TAG(n),    &
                               comm%cart,                &
                               comm%err)
 

--- a/src/3d/fields/field_mpi.f90
+++ b/src/3d/fields/field_mpi.f90
@@ -102,7 +102,7 @@ module field_mpi
             double precision, dimension(:), pointer :: send_buf, recv_buf
             type(MPI_Request)                       :: requests(8)
             type(MPI_Status)                        :: statuses(8)
-            integer                                 :: tag, n, lb, ub
+            integer                                 :: tag, n, recv_size, send_size
 
             do n = 1, 8
 
@@ -110,11 +110,10 @@ module field_mpi
 
                 call get_interior_buffer_ptr(tag, recv_buf)
 
-                lb = lbound(recv_buf)
-                ub = ubound(recv_buf)
+                recv_size = size(recv_buf)
 
-                call MPI_Irecv(recv_buf(lb:ub),         &
-                               size(recv_buf),          &
+                call MPI_Irecv(recv_buf(1:recv_size),   &
+                               recv_size,               &
                                MPI_DOUBLE_PRECISION,    &
                                neighbours(tag)%rank,    &
                                tag,                     &
@@ -129,15 +128,14 @@ module field_mpi
 
                 call get_halo_buffer_ptr(n, send_buf)
 
-                lb = lbound(send_buf)
-                ub = ubound(send_buf)
+                send_size = size(send_buf)
 
-                call MPI_Send(send_buf(lb:ub),         &
-                              size(send_buf),          &
-                              MPI_DOUBLE_PRECISION,    &
-                              neighbours(n)%rank,      &
-                              NEIGHBOUR_TAG(n),        &
-                              comm%cart,               &
+                call MPI_Send(send_buf(1:send_size),    &
+                              send_size,                &
+                              MPI_DOUBLE_PRECISION,     &
+                              neighbours(n)%rank,       &
+                              NEIGHBOUR_TAG(n),         &
+                              comm%cart,                &
                               comm%err)
 
                 call mpi_check_for_error("in MPI_Send of field_mpi::halo_to_interior_communication.")
@@ -158,7 +156,7 @@ module field_mpi
             double precision, dimension(:), pointer :: send_buf, recv_buf
             type(MPI_Request)                       :: requests(8)
             type(MPI_Status)                        :: statuses(8)
-            integer                                 :: tag, n, lb, ub
+            integer                                 :: tag, n, recv_size, send_size
 
             do n = 1, 8
 
@@ -166,11 +164,10 @@ module field_mpi
 
                 call get_halo_buffer_ptr(tag, recv_buf)
 
-                lb = lbound(recv_buf)
-                ub = ubound(recv_buf)
+                recv_size = size(recv_buf)
 
-                call MPI_Irecv(recv_buf(lb:ub),         &
-                               size(recv_buf),          &
+                call MPI_Irecv(recv_buf(1:recv_size),   &
+                               recv_size,               &
                                MPI_DOUBLE_PRECISION,    &
                                neighbours(tag)%rank,    &
                                tag,                     &
@@ -185,15 +182,14 @@ module field_mpi
             do n = 1, 8
                 call get_interior_buffer_ptr(n, send_buf)
 
-                lb = lbound(send_buf)
-                ub = ubound(send_buf)
+                send_size = size(send_buf)
 
-                call MPI_Send(send_buf(lb:ub),         &
-                              size(send_buf),          &
-                              MPI_DOUBLE_PRECISION,    &
-                              neighbours(n)%rank,      &
-                              NEIGHBOUR_TAG(n),        &
-                              comm%cart,               &
+                call MPI_Send(send_buf(1:send_size),    &
+                              send_size,                &
+                              MPI_DOUBLE_PRECISION,     &
+                              neighbours(n)%rank,       &
+                              NEIGHBOUR_TAG(n),         &
+                              comm%cart,                &
                               comm%err)
 
                 call mpi_check_for_error("in MPI_Send of field_mpi::interior_to_halo_communication.")

--- a/src/3d/fields/fields.f90
+++ b/src/3d/fields/fields.f90
@@ -6,7 +6,8 @@ module fields
     use dimensions, only : n_dim, I_X, I_Y, I_Z
     use parameters, only : dx, dxi, extent, lower, nx, ny, nz
     use constants, only : zero
-    use mpi_layout
+    use mpi_communicator
+    use mpi_layout, only : box, l_mpi_layout_initialised
     implicit none
 
     ! x: zonal
@@ -60,11 +61,13 @@ module fields
         subroutine field_alloc
             integer :: hlo(3), hhi(3)
 
+            if (.not. l_mpi_layout_initialised) then
+                call MPI_Abort(comm%world, -1, comm%err)
+            endif
+
             if (allocated(velog)) then
                 return
             endif
-
-            call mpi_layout_init(lower, extent, nx, ny, nz)
 
             hlo = box%hlo
             hhi = box%hhi

--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -362,6 +362,8 @@ module inversion_mod
             call field_halo_fill(vtend(:, :, :, I_Y))
             call field_halo_fill(vtend(:, :, :, I_Z))
 
+            call stop_timer(vtend_timer)
+
         end subroutine vorticity_tendency
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/src/3d/inversion/inversion_utils.f90
+++ b/src/3d/inversion/inversion_utils.f90
@@ -218,8 +218,13 @@ module inversion_utils
             !---------------------------------------------------------------------
             !Define gamtop as the integral of phip(iz, 0, 0) with zero average:
 
-            call MPI_Allreduce(MPI_IN_PLACE, phip00, nz+1, MPI_DOUBLE_PRECISION, &
-                               MPI_SUM, comm%world, comm%err)
+            call MPI_Allreduce(MPI_IN_PLACE,            &
+                               phip00(0:nz),            &
+                               nz+1,                    &
+                               MPI_DOUBLE_PRECISION,    &
+                               MPI_SUM,                 &
+                               comm%world,              &
+                               comm%err)
 
             !$omp parallel workshare
             gamtop = f12 * extent(3) * (phip00 ** 2 - f13)

--- a/src/3d/parcels/parcel_bc.f90
+++ b/src/3d/parcels/parcel_bc.f90
@@ -7,7 +7,7 @@ module parcel_bc
     use constants, only : zero, two
     use parameters, only : lower, upper, extent, hli, center
     use parcel_container, only : n_parcels, parcels
-    use parcel_mpi, only : parcel_halo_swap
+    use parcel_mpi, only : parcel_communicate
     use omp_lib
     implicit none
 
@@ -80,14 +80,14 @@ module parcel_bc
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-        ! Performs a parcel halo swap and then applies the periodic boundary condition
+        ! Performs a parcel swap and then applies the periodic boundary condition
         ! to all parcels
         ! @param[in] pindex are the parcel indices to check (optional)
         subroutine apply_swap_periodicity(pindex)
             integer, optional, intent(in) :: pindex(:)
             integer                       :: n
 
-            call parcel_halo_swap(pindex)
+            call parcel_communicate(pindex)
 
             !$omp parallel default(shared)
             !$omp do private(n)

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -407,8 +407,8 @@ module parcel_container
                 k = k - 1
             enddo
 
-            if (l == 0) then
-                print *, "Error: All parcels are invalid."
+            if (l == -1) then
+                print *, "Error: more than all parcels are invalid."
                 stop
             endif
 

--- a/src/3d/parcels/parcel_correction.f90
+++ b/src/3d/parcels/parcel_correction.f90
@@ -60,8 +60,13 @@ module parcel_correction
 
             buf(1) = vsum
             buf(2:4) = vor_bar
-            call MPI_Allreduce(MPI_IN_PLACE, buf, 4, MPI_DOUBLE_PRECISION, &
-                               MPI_SUM, comm%world, comm%err)
+            call MPI_Allreduce(MPI_IN_PLACE,            &
+                               buf(1:4),                &
+                               4,                       &
+                               MPI_DOUBLE_PRECISION,    &
+                               MPI_SUM,                 &
+                               comm%world,              &
+                               comm%err)
 
             call mpi_check_for_error("in MPI_Allreduce of parcel_correction::init_parcel_correction.")
 
@@ -99,8 +104,13 @@ module parcel_correction
 
             buf(1) = vsum
             buf(2:4) = dvor
-            call MPI_Allreduce(MPI_IN_PLACE, buf, 4, MPI_DOUBLE_PRECISION, &
-                               MPI_SUM, comm%world, comm%err)
+            call MPI_Allreduce(MPI_IN_PLACE,            &
+                               buf(1:4),                &
+                               4,                       &
+                               MPI_DOUBLE_PRECISION,    &
+                               MPI_SUM,                 &
+                               comm%world,              &
+                               comm%err)
 
             call mpi_check_for_error("in MPI_Allreduce of parcel_correction::apply_vortcor.")
             vsum = buf(1)

--- a/src/3d/parcels/parcel_mpi.f90
+++ b/src/3d/parcels/parcel_mpi.f90
@@ -143,7 +143,7 @@ module parcel_mpi
                     call parcel_pack(pid, n_parcel_sends(n), send_buf)
                 endif
 
-                call MPI_Isend(send_buf,                &
+                call MPI_Isend(send_buf(1:send_size),   &
                                send_size,               &
                                MPI_DOUBLE_PRECISION,    &
                                neighbours(n)%rank,      &
@@ -162,7 +162,7 @@ module parcel_mpi
 
                 allocate(recv_buf(recv_size))
 
-                call MPI_Recv(recv_buf,                 &
+                call MPI_Recv(recv_buf(1:recv_size),    &
                               recv_size,                &
                               MPI_DOUBLE_PRECISION,     &
                               source,                   &

--- a/src/3d/parcels/parcel_mpi.f90
+++ b/src/3d/parcels/parcel_mpi.f90
@@ -1,6 +1,8 @@
 module parcel_mpi
     use mpi_layout
-    use mpi_utils, only : mpi_exit_on_error, mpi_check_for_message, mpi_check_for_error
+    use mpi_utils, only : mpi_exit_on_error     &
+                        , mpi_check_for_message &
+                        , mpi_check_for_error
     use mpi_tags
 #ifndef NDEBUG
     use mpi_collectives, only : mpi_blocking_reduce
@@ -32,7 +34,7 @@ module parcel_mpi
     ! we have 8 neighbours
     integer :: n_parcel_sends(8)
 
-    public :: parcel_halo_swap,             &
+    public :: parcel_communicate,             &
               n_parcel_sends,               &
               north_pid,                    &
               south_pid,                    &
@@ -102,7 +104,7 @@ module parcel_mpi
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-        subroutine parcel_halo_swap(pindex)
+        subroutine parcel_communicate(pindex)
             integer, optional, intent(in)           :: pindex(:)
 
             ! We only must store the parcel indices (therefore 1) and
@@ -120,7 +122,7 @@ module parcel_mpi
 
             call deallocate_parcel_buffers
 
-        end subroutine parcel_halo_swap
+        end subroutine parcel_communicate
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -131,7 +133,7 @@ module parcel_mpi
             type(MPI_Request)                       :: requests(8)
             type(MPI_Status)                        :: recv_status, send_statuses(8)
             integer                                 :: n_total_sends, n
-            integer                                 :: tag, source, recv_count
+            integer                                 :: recv_count
             integer                                 :: recv_size, send_size
 
             do n = 1, 8
@@ -147,7 +149,7 @@ module parcel_mpi
                                send_size,               &
                                MPI_DOUBLE_PRECISION,    &
                                neighbours(n)%rank,      &
-                               NEIGHBOUR_TAG(n),        &
+                               SEND_NEIGHBOUR_TAG(n),   &
                                comm%cart,               &
                                requests(n),             &
                                comm%err)
@@ -158,15 +160,17 @@ module parcel_mpi
             do n = 1, 8
 
                 ! check for incoming messages
-                call mpi_check_for_message(tag, recv_size, source)
+                call mpi_check_for_message(neighbours(n)%rank,      &
+                                           RECV_NEIGHBOUR_TAG(n),   &
+                                           recv_size)
 
                 allocate(recv_buf(recv_size))
 
                 call MPI_Recv(recv_buf(1:recv_size),    &
                               recv_size,                &
                               MPI_DOUBLE_PRECISION,     &
-                              source,                   &
-                              tag,                      &
+                              neighbours(n)%rank,       &
+                              RECV_NEIGHBOUR_TAG(n),    &
                               comm%cart,                &
                               recv_status,              &
                               comm%err)

--- a/src/3d/parcels/parcel_nearest.f90
+++ b/src/3d/parcels/parcel_nearest.f90
@@ -549,8 +549,6 @@ module parcel_nearest
             integer                                 :: recv_size, send_size, buf_sizes(8)
             integer                                 :: tag, source, recv_count, n, l, i, m, k, j
             integer, parameter                      :: n_entries = 3
-            integer                                 :: lb, ub
-
 
             buf_sizes = n_neighbour_small * n_entries
             call allocate_mpi_buffers(buf_sizes)
@@ -565,9 +563,6 @@ module parcel_nearest
                 send_size = n_neighbour_small(n) * n_entries
 
                 call get_mpi_buffer(n, send_buf)
-
-                lb = lbound(send_buf)
-                ub = ubound(send_buf)
 
                 do l = 1, n_neighbour_small(n)
                     i = 1 + (l-1) * n_entries
@@ -586,7 +581,7 @@ module parcel_nearest
 
                 tag = small_recv_order(n)
 
-                call MPI_Isend(send_buf(lb:ub),         &
+                call MPI_Isend(send_buf(1:send_size),   &
                                send_size,               &
                                MPI_DOUBLE_PRECISION,    &
                                neighbours(tag)%rank,    &
@@ -1182,7 +1177,6 @@ module parcel_nearest
             integer                                 :: tag, source, recv_count, n, i ,j, l, m, pid, k
             integer, parameter                      :: n_entries = 5
             integer, allocatable                    :: rtmp(:), pidtmp(:), midtmp(:)
-            integer                                 :: lb, ub
             ! rtmp: MPI rank remote small parcel belongs to
             ! pidtmp: parcel index of remote parcel (on the owning rank)
             ! midtmp: m index of remote parcel (on the owning rank)
@@ -1203,9 +1197,6 @@ module parcel_nearest
                 ! per small parcel: 1. local parcel index; 2. merge index *m*
                 call get_parcel_buffer_ptr(n, send_ptr, send_buf)
 
-                lb = lbound(send_buf)
-                ub = ubound(send_buf)
-
                 send_size = n_parcel_sends(n) * n_entries
 
                 if (n_parcel_sends(n) > 0) then
@@ -1220,7 +1211,7 @@ module parcel_nearest
                     enddo
                 endif
 
-                call MPI_Isend(send_buf(lb:ub),         &
+                call MPI_Isend(send_buf(1:send_size),   &
                                send_size,               &
                                MPI_DOUBLE_PRECISION,    &
                                neighbours(n)%rank,      &
@@ -1346,7 +1337,7 @@ module parcel_nearest
             integer, asynchronous                      :: n_parcel_recvs(8)
             type(MPI_Win)                              :: win_neighbour
             integer(KIND=MPI_ADDRESS_KIND)             :: win_size, offset
-            integer                                    :: n_registered(8), lb, ub
+            integer                                    :: n_registered(8)
 
             !------------------------------------------------------------------
             ! Figure out how many parcels we send:
@@ -1450,12 +1441,9 @@ module parcel_nearest
             do n = 1, 8
                 call get_mpi_buffer(n, send_buf)
 
-                lb = lbound(send_buf)
-                ub = ubound(send_buf)
-
                 send_size = n_parcel_sends(n) * n_entries
 
-                call MPI_Isend(send_buf(lb:ub),         &
+                call MPI_Isend(send_buf(1:send_size),   &
                                send_size,               &
                                MPI_DOUBLE_PRECISION,    &
                                neighbours(n)%rank,      &

--- a/src/3d/parcels/parcel_nearest.f90
+++ b/src/3d/parcels/parcel_nearest.f90
@@ -674,9 +674,9 @@ module parcel_nearest
                 ! reset relevant properties for candidate mergers
 
                 ! synchronize the private and public window copies
-                call MPI_Win_sync(win_merged, comm%err)
-                call MPI_Win_sync(win_avail, comm%err)
-                call MPI_Win_sync(win_leaf, comm%err)
+                !call MPI_Win_sync(win_merged, comm%err)
+                !call MPI_Win_sync(win_avail, comm%err)
+                !call MPI_Win_sync(win_leaf, comm%err)
 
                 do m = 1, n_local_small
                     is = isma(m)
@@ -721,7 +721,7 @@ module parcel_nearest
                 call MPI_Barrier(comm%world, comm%err)
 
                 ! synchronize the private and public window copies
-                call MPI_Win_sync(win_avail, comm%err)
+                !call MPI_Win_sync(win_avail, comm%err)
 
                 ! determine leaf parcels
                 do m = 1, n_local_small
@@ -756,7 +756,7 @@ module parcel_nearest
                 call MPI_Barrier(comm%world, comm%err)
 
                 ! synchronize the private and public window copies
-                call MPI_Win_sync(win_leaf, comm%err)
+                !call MPI_Win_sync(win_leaf, comm%err)
 
                 ! filter out parcels that are "unavailable" for merging
                 do m = 1, n_local_small
@@ -793,7 +793,7 @@ module parcel_nearest
                 call MPI_Barrier(comm%world, comm%err)
 
                 ! synchronize the private and public window copies
-                call MPI_Win_sync(win_avail, comm%err)
+                !call MPI_Win_sync(win_avail, comm%err)
 
                 ! identify mergers in this iteration
                 do m = 1, n_local_small
@@ -876,9 +876,9 @@ module parcel_nearest
             call MPI_Barrier(comm%world, comm%err)
 
             ! synchronize the private and public window copies
-            call MPI_Win_sync(win_merged, comm%err)
-            call MPI_Win_sync(win_avail, comm%err)
-            call MPI_Win_sync(win_leaf, comm%err)
+            !call MPI_Win_sync(win_merged, comm%err)
+            !call MPI_Win_sync(win_avail, comm%err)
+            !call MPI_Win_sync(win_leaf, comm%err)
 
 
             ! Second stage, related to dual links
@@ -918,7 +918,7 @@ module parcel_nearest
             call MPI_Barrier(comm%world, comm%err)
 
             ! synchronize the private and public window copies
-            call MPI_Win_sync(win_avail, comm%err)
+            !call MPI_Win_sync(win_avail, comm%err)
 
             ! Second stage
             do m = 1, n_local_small
@@ -1016,7 +1016,7 @@ module parcel_nearest
             call MPI_Barrier(comm%world, comm%err)
 
             ! synchronize the private and public window copies
-            call MPI_Win_sync(win_avail, comm%err)
+            !call MPI_Win_sync(win_avail, comm%err)
 
 
             !------------------------------------------------------
@@ -1062,7 +1062,7 @@ module parcel_nearest
             call MPI_Barrier(comm%world, comm%err)
 
             ! synchronize the private and public window copies
-            call MPI_Win_sync(win_avail, comm%err)
+            !call MPI_Win_sync(win_avail, comm%err)
 
             j = 0
             do m = 1, n_local_small
@@ -1432,7 +1432,7 @@ module parcel_nearest
 
             call MPI_Win_unlock_all(win_neighbour, comm%err)
 
-            call MPI_Win_sync(win_neighbour, comm%err)
+            !call MPI_Win_sync(win_neighbour, comm%err)
 
             call MPI_Win_free(win_neighbour, comm%err)
 

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -295,7 +295,7 @@ module parcel_netcdf
             sendbuf(comm%rank+1:comm%size) = n_parcels
             sendbuf(comm%rank+1) = 0
 
-            call MPI_Reduce_scatter(sendbuf, start_index, recvcounts, MPI_INT, MPI_SUM, comm%world, comm%err)
+            call MPI_Reduce_scatter(sendbuf, start_index, recvcounts, MPI_INTEGER, MPI_SUM, comm%world, comm%err)
 
             call mpi_check_for_error("in MPI_Reduce_scatter of parcel_netcdf::write_netcdf_parcels.")
 
@@ -432,7 +432,7 @@ module parcel_netcdf
 
             ! verify result
             n_total = n_parcels
-            call MPI_Allreduce(MPI_IN_PLACE, n_total, 1, MPI_INT, MPI_SUM, comm%world, comm%err)
+            call MPI_Allreduce(MPI_IN_PLACE, n_total, 1, MPI_INTEGER, MPI_SUM, comm%world, comm%err)
             call mpi_check_for_error("in MPI_Allreduce of parcel_netcdf::read_netcdf_parcels.")
             if (n_total_parcels .ne. n_total) then
                 call mpi_exit_on_error("Local number of parcels does not sum up to total number!")

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -295,7 +295,13 @@ module parcel_netcdf
             sendbuf(comm%rank+1:comm%size) = n_parcels
             sendbuf(comm%rank+1) = 0
 
-            call MPI_Reduce_scatter(sendbuf, start_index, recvcounts, MPI_INTEGER, MPI_SUM, comm%world, comm%err)
+            call MPI_Reduce_scatter(sendbuf(1:comm%size),   &
+                                    start_index,            &
+                                    recvcounts,             &
+                                    MPI_INTEGER,            &
+                                    MPI_SUM,                &
+                                    comm%world,             &
+                                    comm%err)
 
             call mpi_check_for_error("in MPI_Reduce_scatter of parcel_netcdf::write_netcdf_parcels.")
 

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -348,8 +348,9 @@ module parcel_netcdf
             character(*),     intent(in) :: fname
             integer                      :: start_index, num_indices, end_index
             integer, allocatable         :: invalid(:)
-            integer                      :: n, m, n_total, pid
+            integer                      :: n, m, n_total, pfirst, plast
             integer                      :: start(2)
+            integer                      :: avail_size, n_remaining, n_read
 
             call start_timer(parcel_io_timer)
 
@@ -380,8 +381,8 @@ module parcel_netcdf
                 n_parcels = end_index - start_index + 1
 
                 if (n_parcels > max_num_parcels) then
-                    print *, "Number of parcels exceeds limit of", &
-                            max_num_parcels, ". Exiting."
+                    print *, "Number of parcels exceeds limit of", max_num_parcels, &
+                             ". You may increase parcel%size_factor. Exiting."
                     call MPI_Abort(comm%world, -1, comm%err)
                     call mpi_check_for_error("in MPI_Abort of parcel_netcdf::read_netcdf_parcels.")
                 endif
@@ -396,8 +397,8 @@ module parcel_netcdf
                 call mpi_print("WARNING: The start index is not provided. All MPI ranks read all parcels!")
                 start_index = 1
                 end_index = min(max_num_parcels, n_total_parcels)
-                n_parcels = end_index
-                pid = 1
+                pfirst = 1
+                n_remaining = n_total_parcels
 
                 ! if all MPI ranks read all parcels, each MPI rank must delete the parcels
                 ! not belonging to its domain
@@ -405,10 +406,14 @@ module parcel_netcdf
 
                 do while (start_index <= end_index)
 
-                    call read_chunk(start_index, end_index, pid)
+                    call read_chunk(start_index, end_index, pfirst)
+
+                    n_read = end_index - start_index + 1
+                    n_remaining = n_remaining - n_read
+                    n_parcels = pfirst + n_read - 1
 
                     m = 1
-                    do n = pid, n_parcels
+                    do n = pfirst, n_parcels
                         if (is_contained(parcels%position(:, n))) then
                             cycle
                         endif
@@ -424,14 +429,24 @@ module parcel_netcdf
                     ! updates the variable n_parcels
                     call parcel_delete(invalid(0:m), n_del=m)
 
+                    ! adjust the chunk size to fit the remaining memory
+                    ! in the parcel container
+                    avail_size = max(0, max_num_parcels - n_parcels)
+
+                    ! update start index to fill container
+                    pfirst = 1 + n_parcels
+                    plast = min(pfirst + avail_size, n_total_parcels, max_num_parcels)
+
+                    ! we must make sure that we have enough data in the
+                    ! file as well as in the parcel container
+                    n_read = min(plast - pfirst, n_remaining)
+
+                    ! update start and end index for reading chunk
                     start_index = 1 + end_index
-                    end_index = min(end_index + max_num_parcels, n_total_parcels)
-                    pid = n_parcels + 1
-                    n_parcels = n_parcels + end_index - start_index + 1
+                    end_index = end_index + n_read
                 enddo
 
                 deallocate(invalid)
-
             endif
 
             call close_netcdf_file(ncid)
@@ -459,74 +474,81 @@ module parcel_netcdf
             num = last - first + 1
             plast = pfirst + num - 1
 
+            if (plast > max_num_parcels) then
+                print *, "Number of parcels exceeds limit of", max_num_parcels, &
+                         ". You may increase parcel%size_factor. Exiting."
+                call MPI_Abort(comm%world, -1, comm%err)
+                call mpi_check_for_error("in MPI_Abort of parcel_netcdf::read_chunk.")
+            endif
+
             start = (/ first, 1 /)
             cnt   = (/ num,   1 /)
 
             if (has_dataset(ncid, 'B11')) then
                 call read_netcdf_dataset(ncid, 'B11', parcels%B(1, pfirst:plast), start, cnt)
             else
-                print *, "The parcel shape component B11 must be present! Exiting."
-                stop
+                call mpi_exit_on_error(&
+                    "The parcel shape component B11 must be present! Exiting.")
             endif
 
             if (has_dataset(ncid, 'B12')) then
                 call read_netcdf_dataset(ncid, 'B12', parcels%B(2, pfirst:plast), start, cnt)
             else
-                print *, "The parcel shape component B12 must be present! Exiting."
-                stop
+                call mpi_exit_on_error(&
+                    "The parcel shape component B12 must be present! Exiting.")
             endif
 
             if (has_dataset(ncid, 'B13')) then
                 call read_netcdf_dataset(ncid, 'B13', parcels%B(3, pfirst:plast), start, cnt)
             else
-                print *, "The parcel shape component B13 must be present! Exiting."
-                stop
+                call mpi_exit_on_error(&
+                    "The parcel shape component B13 must be present! Exiting.")
             endif
 
             if (has_dataset(ncid, 'B22')) then
                 call read_netcdf_dataset(ncid, 'B22', parcels%B(4, pfirst:plast), start, cnt)
             else
-                print *, "The parcel shape component B22 must be present! Exiting."
-                stop
+                call mpi_exit_on_error(&
+                    "The parcel shape component B22 must be present! Exiting.")
             endif
 
             if (has_dataset(ncid, 'B23')) then
                 call read_netcdf_dataset(ncid, 'B23', parcels%B(5, pfirst:plast), start, cnt)
             else
-                print *, "The parcel shape component B23 must be present! Exiting."
-                stop
+                call mpi_exit_on_error(&
+                    "The parcel shape component B23 must be present! Exiting.")
             endif
 
             if (has_dataset(ncid, 'x_position')) then
                 call read_netcdf_dataset(ncid, 'x_position', &
                                          parcels%position(1, pfirst:plast), start, cnt)
             else
-                print *, "The parcel x position must be present! Exiting."
-                stop
+                call mpi_exit_on_error(&
+                    "The parcel x position must be present! Exiting.")
             endif
 
             if (has_dataset(ncid, 'y_position')) then
                 call read_netcdf_dataset(ncid, 'y_position', &
                                          parcels%position(2, pfirst:plast), start, cnt)
             else
-                print *, "The parcel y position must be present! Exiting."
-                stop
+                call mpi_exit_on_error(&
+                    "The parcel y position must be present! Exiting.")
             endif
 
             if (has_dataset(ncid, 'z_position')) then
                 call read_netcdf_dataset(ncid, 'z_position', &
                                          parcels%position(3, pfirst:plast), start, cnt)
             else
-                print *, "The parcel z position must be present! Exiting."
-                stop
+                call mpi_exit_on_error(&
+                    "The parcel z position must be present! Exiting.")
             endif
 
             if (has_dataset(ncid, 'volume')) then
                 call read_netcdf_dataset(ncid, 'volume', &
                                          parcels%volume(pfirst:plast), start, cnt)
             else
-                print *, "The parcel volume must be present! Exiting."
-                stop
+                call mpi_exit_on_error(&
+                    "The parcel volume must be present! Exiting.")
             endif
 
             if (has_dataset(ncid, 'x_vorticity')) then
@@ -561,8 +583,8 @@ module parcel_netcdf
 #endif
 
             if (.not. l_valid) then
-                print *, "Either the parcel buoyancy or vorticity must be present! Exiting."
-                stop
+                call mpi_exit_on_error(&
+                    "Either the parcel buoyancy or vorticity must be present! Exiting.")
             endif
         end subroutine read_chunk
 

--- a/src/3d/stepper/rk4_utils.f90
+++ b/src/3d/stepper/rk4_utils.f90
@@ -168,8 +168,13 @@ module rk4_utils
             local_max(1) = gmax
             local_max(2) = bmax
 
-            call MPI_Allreduce(MPI_IN_PLACE, local_max, 2, MPI_DOUBLE_PRECISION, &
-                               MPI_MAX, comm%world, comm%err)
+            call MPI_Allreduce(MPI_IN_PLACE,            &
+                               local_max(1:2),          &
+                               2,                       &
+                               MPI_DOUBLE_PRECISION,    &
+                               MPI_MAX,                 &
+                               comm%world,              &
+                               comm%err)
 
             gmax = local_max(1)
             bmax = local_max(2)

--- a/src/3d/utils/parameters.f90
+++ b/src/3d/utils/parameters.f90
@@ -3,11 +3,13 @@
 ! simulation.
 ! =============================================================================
 module parameters
-    use options, only : allow_larger_anisotropy, parcel, boundary, mpi_info
+    use options, only : allow_larger_anisotropy, parcel, boundary
     use constants
     use netcdf_reader
     use netcdf_utils
     use netcdf_writer
+    use mpi_communicator
+    use mpi_layout, only : box, l_mpi_layout_initialised
     implicit none
 
     ! mesh spacing
@@ -89,6 +91,13 @@ module parameters
     subroutine update_parameters
         double precision :: msr
 
+        if (.not. l_mpi_layout_initialised) then
+            if (comm%rank == comm%master) then
+                print *, "MPI layout is not initialsed!"
+            endif
+            call MPI_Abort(comm%world, -1, comm%err)
+        endif
+
         upper = lower + extent
 
         extenti = one / extent
@@ -101,14 +110,16 @@ module parameters
                        dxi(2) * dx(3), dxi(3) * dx(2)/))
 
         if (msr > two) then
-            print *, '**********************************************************************'
-            print *, '*                                                                    *'
-            print *, '*   Warning: A mesh spacing ratio of more than 2 is not advisable!   *'
-            print *, '*                                                                    *'
-            print *, '**********************************************************************'
+            if (comm%rank == comm%master) then
+                print *, '**********************************************************************'
+                print *, '*                                                                    *'
+                print *, '*   Warning: A mesh spacing ratio of more than 2 is not advisable!   *'
+                print *, '*                                                                    *'
+                print *, '**********************************************************************'
+            endif
 
             if (.not. allow_larger_anisotropy) then
-                stop
+                call MPI_Abort(comm%world, -1, comm%err)
             endif
         endif
 
@@ -136,24 +147,43 @@ module parameters
         vmin = vcell / parcel%min_vratio
         vmax = vcell / parcel%max_vratio
 
-        max_num_parcels = int(nx * ny * nz * parcel%min_vratio * parcel%size_factor)
+        max_num_parcels = int(box%ncell * parcel%min_vratio * parcel%size_factor)
 
     end subroutine update_parameters
 
 
     subroutine set_zeta_boundary_flag(zeta)
-        double precision, intent(in) :: zeta(-1:nz+1, 0:ny-1, 0:nx-1)
+        double precision, intent(in) :: zeta(-1:nz+1,                &
+                                             box%hlo(2):box%hhi(2),  &
+                                             box%hlo(1):box%hhi(1))
         double precision             :: rms_bndry(2), rms_interior, thres
+        double precision             :: val(3)
 
         if (boundary%l_ignore_bndry_zeta_flag) then
             l_bndry_zeta_zero(:) = .false.
-            print *, "WARNING: You allow the gridded vertical vorticity component"
-            print *, "         at the boundaries to develop non-zero values."
-            print *, "         Stop your simulation if this is not your intention."
+            if (comm%rank == comm%master) then
+                print *, "WARNING: You allow the gridded vertical vorticity component"
+                print *, "         at the boundaries to develop non-zero values."
+                print *, "         Stop your simulation if this is not your intention."
+            endif
         else
-            rms_interior = dsqrt(sum(zeta(1:nz-1, :, :) ** 2) * nhcelli / (nz-1))
-            rms_bndry(1) = dsqrt(sum(zeta(0,      :, :) ** 2) * nhcelli)
-            rms_bndry(2) = dsqrt(sum(zeta(nz,     :, :) ** 2) * nhcelli)
+            ! rms interior
+            val(1) = sum(zeta(1:nz-1, box%lo(2):box%hi(2), box%lo(1):box%hi(1)) ** 2)
+
+            ! rms boundary
+            val(2) = sum(zeta(0,      box%lo(2):box%hi(2), box%lo(1):box%hi(1)) ** 2)
+            val(3) = sum(zeta(nz,     box%lo(2):box%hi(2), box%lo(1):box%hi(1)) ** 2)
+
+            call MPI_Allreduce(MPI_IN_PLACE,            &
+                               val(1:3),                &
+                               3,                       &
+                               MPI_DOUBLE_PRECISION,    &
+                               MPI_SUM,                 &
+                               comm%world,              &
+                               comm%err)
+
+            rms_interior = dsqrt(val(1) * nhcelli / (nz-1))
+            rms_bndry = dsqrt(val(2:3) * nhcelli)
 
             thres = boundary%zeta_tol * rms_interior + epsilon(rms_interior)
 
@@ -161,12 +191,12 @@ module parameters
         endif
 
 #if defined(ENABLE_VERBOSE) || !defined(NDEBUG)
-        if (.not. l_bndry_zeta_zero(1)) then
+        if ((.not. l_bndry_zeta_zero(1)) .and. (comm%rank == comm%master)) then
             print *, "WARNING: This simulation will not ensure that the gridded vertical"
             print *, "         vorticity component is zero at the lower boundary."
         endif
 
-        if (.not. l_bndry_zeta_zero(2)) then
+        if ((.not. l_bndry_zeta_zero(2)) .and. (comm%rank == comm%master)) then
             print *, "WARNING: This simulation will not ensure that the gridded vertical"
             print *, "         vorticity component is zero at the upper boundary."
         endif
@@ -181,9 +211,11 @@ module parameters
 
         if (boundary%l_ignore_bndry_zeta_flag) then
             l_bndry_zeta_zero(:) = .false.
-            print *, "WARNING: You allow the gridded vertical vorticity component"
-            print *, "         at the boundaries to develop non-zero values."
-            print *, "         Stop your simulation if this is not your intention."
+            if (comm%rank == comm%master) then
+                print *, "WARNING: You allow the gridded vertical vorticity component"
+                print *, "         at the boundaries to develop non-zero values."
+                print *, "         Stop your simulation if this is not your intention."
+            endif
             return
         endif
 
@@ -193,11 +225,13 @@ module parameters
             call read_netcdf_attribute(grp_ncid, 'l_lower_boundry_zeta_zero', l_bndry_zeta_zero(1))
             call read_netcdf_attribute(grp_ncid, 'l_upper_boundry_zeta_zero', l_bndry_zeta_zero(2))
         else
-            print *, "WARNING: Could not find a '" // name // "' group in the provided"
-            print *, "         NetCDF file."
-            print *, "         Note this will result in the boundary zeta flags being"
-            print *, "         set to false starting with parcels (which could well be"
-            print *, "         undesirable)."
+            if (comm%rank == comm%master) then
+                print *, "WARNING: Could not find a '" // name // "' group in the provided"
+                print *, "         NetCDF file."
+                print *, "         Note this will result in the boundary zeta flags being"
+                print *, "         set to false starting with parcels (which could well be"
+                print *, "         undesirable)."
+            endif
         endif
 
     end subroutine read_zeta_boundary_flag

--- a/src/3d/utils/utils.f90
+++ b/src/3d/utils/utils.f90
@@ -21,6 +21,8 @@ module utils
     use parameters, only : lower, extent, update_parameters, read_zeta_boundary_flag &
                          , set_zeta_boundary_flag
     use physics, only : read_physical_quantities, print_physical_quantities
+    use mpi_layout, only : mpi_layout_init
+    use mpi_utils, only : mpi_exit_on_error
     implicit none
 
     integer :: nfw  = 0    ! number of field writes
@@ -170,6 +172,8 @@ module utils
             ny = ncells(2)
             nz = ncells(3)
 
+            call mpi_layout_init(lower, extent, nx, ny, nz)
+
             ! update global parameters
             call update_parameters
 
@@ -193,11 +197,11 @@ module utils
 
                 if (file_type == 'fields') then
                     call read_netcdf_fields(trim(restart_file), -1)
+                    call init_parcels_from_grids
                 else if (file_type == 'parcels') then
                     call read_netcdf_parcels(restart_file)
                 else
-                    print *, 'Restart file must be of type "fields" or "parcels".'
-                    stop
+                    call mpi_exit_on_error('Restart file must be of type "fields" or "parcels".')
                 endif
             else
                 time%initial = zero ! make sure user cannot start at arbirtrary time

--- a/src/fft/fft_pencil.f90
+++ b/src/fft/fft_pencil.f90
@@ -75,18 +75,22 @@ contains
             !   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
             call mpi_cart_sub(comm%cart, (/.false., .true./), dim_y_comm, comm%err)
             call mpi_cart_sub(comm%cart, (/.true., .false./), dim_x_comm, comm%err)
-            call mpi_allgather(box%size(I_Y), 1, MPI_INT, y_distinct_sizes, 1, MPI_INT, dim_y_comm, comm%err)
-            call mpi_allgather(box%size(I_X), 1, MPI_INT, x_distinct_sizes, 1, MPI_INT, dim_x_comm, comm%err)
+            call mpi_allgather(box%size(I_Y), 1, MPI_INTEGER, y_distinct_sizes, 1, &
+                               MPI_INTEGER, dim_y_comm, comm%err)
+            call mpi_allgather(box%size(I_X), 1, MPI_INTEGER, x_distinct_sizes, 1, &
+                               MPI_INTEGER, dim_x_comm, comm%err)
         else if (layout%l_parallel(I_Y)) then
             dim_y_comm = comm%world
             dim_x_comm = MPI_COMM_SELF
-            call mpi_allgather(box%size(I_Y), 1, MPI_INT, y_distinct_sizes, 1, MPI_INT, dim_y_comm, comm%err)
+            call mpi_allgather(box%size(I_Y), 1, MPI_INTEGER, y_distinct_sizes, 1, &
+                               MPI_INTEGER, dim_y_comm, comm%err)
             x_distinct_sizes = box%size(I_X)
         else if (layout%l_parallel(I_X)) then
             dim_y_comm = MPI_COMM_SELF
             dim_x_comm = comm%world
             y_distinct_sizes = box%size(I_Y)
-            call mpi_allgather(box%size(I_X), 1, MPI_INT, x_distinct_sizes, 1, MPI_INT, dim_x_comm, comm%err)
+            call mpi_allgather(box%size(I_X), 1, MPI_INTEGER, x_distinct_sizes, 1, &
+                               MPI_INTEGER, dim_x_comm, comm%err)
         else
             dim_y_comm = MPI_COMM_SELF
             dim_x_comm = MPI_COMM_SELF

--- a/src/fft/fft_pencil.f90
+++ b/src/fft/fft_pencil.f90
@@ -284,15 +284,14 @@ contains
         double precision,           intent(out) :: target_data(:, :, :)
         double precision, allocatable, save     :: real_temp(:, :, :)
         double precision, allocatable, save     :: real_temp2(:)
-        integer                                 :: lb, ub
+        integer                                 :: buf_size
+
+        buf_size = product(transposition_description%pencil_size)
 
         !$OMP SINGLE
         allocate(real_temp(size(source_data, 3), size(source_data, 2), size(source_data, 1)))
-        allocate(real_temp2(product(transposition_description%pencil_size)))
+        allocate(real_temp2(buf_size))
         !$OMP END SINGLE
-
-        lb = lbound(real_temp2)
-        ub = ubound(real_temp2)
 
         ! --> realt_temp is x, y, z (c, b, a)
         call rearrange_data_for_sending(real_source=source_data, real_target=real_temp)
@@ -304,7 +303,7 @@ contains
                            transposition_description%send_sizes,    &
                            transposition_description%send_offsets,  &
                            MPI_DOUBLE_PRECISION,                    &
-                           real_temp2(lb:ub),                       &
+                           real_temp2(1:buf_size),                  &
                            transposition_description%recv_sizes,    &
                            transposition_description%recv_offsets,  &
                            MPI_DOUBLE_PRECISION,                    &

--- a/src/mpi/mpi_collectives.f90
+++ b/src/mpi/mpi_collectives.f90
@@ -2,34 +2,12 @@ module mpi_collectives
     use mpi_communicator
     implicit none
 
-!     interface mpi_non_blocking_reduce
-!         module procedure :: mpi_double_ireduce
-!         module procedure :: mpi_integer_ireduce
-!     end interface mpi_non_blocking_reduce
-
     interface mpi_blocking_reduce
         module procedure :: mpi_double_reduce
         module procedure :: mpi_integer_reduce
     end interface mpi_blocking_reduce
 
     contains
-!         subroutine mpi_double_ireduce(sendbuf, recvbuf, op)
-!             double precision,  intent(in),  asynchronous :: sendbuf(..)
-!             double precision,  intent(out), asynchronous :: recvbuf(..)
-!             type(MPI_Op),      intent(in)                :: op
-!             type(MPI_Request)                            :: request
-!             call MPI_Ireduce(sendbuf, recvbuf, size(recvbuf), MPI_DOUBLE_PRECISION, &
-!                              op, 0, comm%world, request, comm%err)
-!         end subroutine mpi_double_ireduce
-
-!         subroutine mpi_integer_ireduce(sendbuf, recvbuf, op)
-!             integer,           intent(in),  asynchronous :: sendbuf(..)
-!             integer,           intent(out), asynchronous :: recvbuf(..)
-!             type(MPI_Op),      intent(in)                :: op
-!             type(MPI_Request)                            :: request
-!             call MPI_Ireduce(sendbuf, recvbuf, size(recvbuf), MPI_INT, &
-!                              op, 0, comm%world, request, comm%err)
-!         end subroutine mpi_integer_ireduce
 
         subroutine mpi_double_reduce(sendbuf, op)
             double precision, intent(inout) :: sendbuf(..)
@@ -49,10 +27,10 @@ module mpi_collectives
             type(MPI_Op), intent(in)    :: op
 
             if (comm%rank == comm%master) then
-                call MPI_Reduce(MPI_IN_PLACE, sendbuf, size(sendbuf), MPI_INT, &
+                call MPI_Reduce(MPI_IN_PLACE, sendbuf, size(sendbuf), MPI_INTEGER, &
                                 op, comm%master, comm%world, comm%err)
             else
-                call MPI_Reduce(sendbuf, sendbuf, size(sendbuf), MPI_INT, &
+                call MPI_Reduce(sendbuf, sendbuf, size(sendbuf), MPI_INTEGER, &
                                 op, comm%master, comm%world, comm%err)
             endif
         end subroutine mpi_integer_reduce

--- a/src/mpi/mpi_p2p.f90
+++ b/src/mpi/mpi_p2p.f90
@@ -36,7 +36,7 @@ module mpi_p2p
             integer,          intent(in)               :: tag
             type(MPI_Request)                          :: request
 
-            call MPI_Isend(data(1:size(data)),      &
+            call MPI_Isend(data,                    &
                            size(data),              &
                            MPI_DOUBLE_PRECISION,    &
                            dest,                    &
@@ -52,13 +52,13 @@ module mpi_p2p
             integer, intent(in)               :: tag
             type(MPI_Request)                 :: request
 
-            call MPI_Isend(data(1:size(data)),  &
-                           size(data),          &
-                           MPI_INTEGER,         &
-                           dest,                &
-                           tag,                 &
-                           comm%world,          &
-                           request,             &
+            call MPI_Isend(data,        &
+                           size(data),  &
+                           MPI_INTEGER, &
+                           dest,        &
+                           tag,         &
+                           comm%world,  &
+                           request,     &
                            comm%err)
         end subroutine mpi_integer_isend
 
@@ -69,7 +69,7 @@ module mpi_p2p
             integer,          intent(in)                :: tag
             type(MPI_Request)                           :: request
 
-            call MPI_Irecv(data(1:size(data)),      &
+            call MPI_Irecv(data,                    &
                            size(data),              &
                            MPI_DOUBLE_PRECISION,    &
                            source,                  &
@@ -85,13 +85,13 @@ module mpi_p2p
             integer, intent(in)                :: tag
             type(MPI_Request)                  :: request
 
-            call MPI_Irecv(data(1:size(data)),  &
-                           size(data),          &
-                           MPI_INTEGER,         &
-                           source,              &
-                           tag,                 &
-                           comm%world,          &
-                           request,             &
+            call MPI_Irecv(data,        &
+                           size(data),  &
+                           MPI_INTEGER, &
+                           source,      &
+                           tag,         &
+                           comm%world,  &
+                           request,     &
                            comm%err)
         end subroutine mpi_integer_irecv
 
@@ -104,7 +104,7 @@ module mpi_p2p
             integer,          intent(in) :: dest
             integer,          intent(in) :: tag
 
-            call MPI_Send(data(1:size(data)),   &
+            call MPI_Send(data,                 &
                           size(data),           &
                           MPI_DOUBLE_PRECISION, &
                           dest,                 &
@@ -118,12 +118,12 @@ module mpi_p2p
             integer, intent(in) :: dest
             integer, intent(in) :: tag
 
-            call MPI_Send(data(1:size(data)),   &
-                          size(data),           &
-                          MPI_INTEGER,          &
-                          dest,                 &
-                          tag,                  &
-                          comm%world,           &
+            call MPI_Send(data,         &
+                          size(data),   &
+                          MPI_INTEGER,  &
+                          dest,         &
+                          tag,          &
+                          comm%world,   &
                           comm%err)
         end subroutine mpi_integer_send
 
@@ -134,7 +134,7 @@ module mpi_p2p
             integer,          intent(in)  :: tag
             type(MPI_Status)              :: status
 
-            call MPI_Recv(data(1:size(data)),   &
+            call MPI_Recv(data,                 &
                           size(data),           &
                           MPI_DOUBLE_PRECISION, &
                           source,               &
@@ -150,13 +150,13 @@ module mpi_p2p
             integer, intent(in)  :: tag
             type(MPI_Status)     :: status
 
-            call MPI_Recv(data(1:size(data)),   &
-                          size(data),           &
-                          MPI_INTEGER,          &
-                          source,               &
-                          tag,                  &
-                          comm%world,           &
-                          status,               &
+            call MPI_Recv(data,         &
+                          size(data),   &
+                          MPI_INTEGER,  &
+                          source,       &
+                          tag,          &
+                          comm%world,   &
+                          status,       &
                           comm%err)
         end subroutine mpi_integer_recv
 

--- a/src/mpi/mpi_p2p.f90
+++ b/src/mpi/mpi_p2p.f90
@@ -35,7 +35,19 @@ module mpi_p2p
             integer,          intent(in)               :: dest
             integer,          intent(in)               :: tag
             type(MPI_Request)                          :: request
-            call MPI_Isend(data, size(data), MPI_DOUBLE_PRECISION, dest, tag, comm%world, request, comm%err)
+            integer                                    :: lb, ub
+
+            lb = lbound(data)
+            ub = ubound(data)
+
+            call MPI_Isend(data(lb:ub),             &
+                           size(data),              &
+                           MPI_DOUBLE_PRECISION,    &
+                           dest,                    &
+                           tag,                     &
+                           comm%world,              &
+                           request,                 &
+                           comm%err)
         end subroutine mpi_double_isend
 
         subroutine mpi_integer_isend(data, dest, tag)
@@ -43,7 +55,19 @@ module mpi_p2p
             integer, intent(in)               :: dest
             integer, intent(in)               :: tag
             type(MPI_Request)                 :: request
-            call MPI_Isend(data, size(data), MPI_INT, dest, tag, comm%world, request, comm%err)
+            integer                           :: lb, ub
+
+            lb = lbound(data)
+            ub = ubound(data)
+
+            call MPI_Isend(data(lb:ub), &
+                           size(data),  &
+                           MPI_INTEGER, &
+                           dest,        &
+                           tag,         &
+                           comm%world,  &
+                           request,     &
+                           comm%err)
         end subroutine mpi_integer_isend
 
 
@@ -52,7 +76,19 @@ module mpi_p2p
             integer,          intent(in)                :: source
             integer,          intent(in)                :: tag
             type(MPI_Request)                           :: request
-            call MPI_Irecv(data, size(data), MPI_DOUBLE_PRECISION, source, tag, comm%world, request, comm%err)
+            integer                                    :: lb, ub
+
+            lb = lbound(data)
+            ub = ubound(data)
+
+            call MPI_Irecv(data(lb:ub),             &
+                           size(data),              &
+                           MPI_DOUBLE_PRECISION,    &
+                           source,                  &
+                           tag,                     &
+                           comm%world,              &
+                           request,                 &
+                           comm%err)
         end subroutine mpi_double_irecv
 
         subroutine mpi_integer_irecv(data, source, tag)
@@ -60,7 +96,19 @@ module mpi_p2p
             integer, intent(in)                :: source
             integer, intent(in)                :: tag
             type(MPI_Request)                  :: request
-            call MPI_Irecv(data, size(data), MPI_INT, source, tag, comm%world, request, comm%err)
+            integer                           :: lb, ub
+
+            lb = lbound(data)
+            ub = ubound(data)
+
+            call MPI_Irecv(data(lb:ub), &
+                           size(data),  &
+                           MPI_INTEGER, &
+                           source,      &
+                           tag,         &
+                           comm%world,  &
+                           request,     &
+                           comm%err)
         end subroutine mpi_integer_irecv
 
 
@@ -71,14 +119,36 @@ module mpi_p2p
             double precision, intent(in) :: data(..)
             integer,          intent(in) :: dest
             integer,          intent(in) :: tag
-            call MPI_Send(data, size(data), MPI_DOUBLE_PRECISION, dest, tag, comm%world, comm%err)
+            integer                      :: lb, ub
+
+            lb = lbound(data)
+            ub = ubound(data)
+
+            call MPI_Send(data(lb:ub),          &
+                          size(data),           &
+                          MPI_DOUBLE_PRECISION, &
+                          dest,                 &
+                          tag,                  &
+                          comm%world,           &
+                          comm%err)
         end subroutine mpi_double_send
 
         subroutine mpi_integer_send(data, dest, tag)
             integer, intent(in) :: data(..)
             integer, intent(in) :: dest
             integer, intent(in) :: tag
-            call MPI_Send(data, size(data), MPI_INT, dest, tag, comm%world, comm%err)
+            integer             :: lb, ub
+
+            lb = lbound(data)
+            ub = ubound(data)
+
+            call MPI_Send(data(lb:ub),  &
+                          size(data),   &
+                          MPI_INTEGER,  &
+                          dest,         &
+                          tag,          &
+                          comm%world,   &
+                          comm%err)
         end subroutine mpi_integer_send
 
 
@@ -87,7 +157,19 @@ module mpi_p2p
             integer,          intent(in)  :: source
             integer,          intent(in)  :: tag
             type(MPI_Status)              :: status
-            call MPI_Recv(data, size(data), MPI_DOUBLE_PRECISION, source, tag, comm%world, status, comm%err)
+            integer                       :: lb, ub
+
+            lb = lbound(data)
+            ub = ubound(data)
+
+            call MPI_Recv(data(lb:ub),          &
+                          size(data),           &
+                          MPI_DOUBLE_PRECISION, &
+                          source,               &
+                          tag,                  &
+                          comm%world,           &
+                          status,               &
+                          comm%err)
         end subroutine mpi_double_recv
 
         subroutine mpi_integer_recv(data, source, tag)
@@ -95,7 +177,19 @@ module mpi_p2p
             integer, intent(in)  :: source
             integer, intent(in)  :: tag
             type(MPI_Status)     :: status
-            call MPI_Recv(data, size(data), MPI_INT, source, tag, comm%world, status, comm%err)
+            integer              :: lb, ub
+
+            lb = lbound(data)
+            ub = ubound(data)
+
+            call MPI_Recv(data(lb:ub),  &
+                          size(data),   &
+                          MPI_INTEGER,  &
+                          source,       &
+                          tag,          &
+                          comm%world,   &
+                          status,       &
+                          comm%err)
         end subroutine mpi_integer_recv
 
 end module mpi_p2p

--- a/src/mpi/mpi_p2p.f90
+++ b/src/mpi/mpi_p2p.f90
@@ -35,12 +35,8 @@ module mpi_p2p
             integer,          intent(in)               :: dest
             integer,          intent(in)               :: tag
             type(MPI_Request)                          :: request
-            integer                                    :: lb, ub
 
-            lb = lbound(data)
-            ub = ubound(data)
-
-            call MPI_Isend(data(lb:ub),             &
+            call MPI_Isend(data(1:size(data)),      &
                            size(data),              &
                            MPI_DOUBLE_PRECISION,    &
                            dest,                    &
@@ -55,18 +51,14 @@ module mpi_p2p
             integer, intent(in)               :: dest
             integer, intent(in)               :: tag
             type(MPI_Request)                 :: request
-            integer                           :: lb, ub
 
-            lb = lbound(data)
-            ub = ubound(data)
-
-            call MPI_Isend(data(lb:ub), &
-                           size(data),  &
-                           MPI_INTEGER, &
-                           dest,        &
-                           tag,         &
-                           comm%world,  &
-                           request,     &
+            call MPI_Isend(data(1:size(data)),  &
+                           size(data),          &
+                           MPI_INTEGER,         &
+                           dest,                &
+                           tag,                 &
+                           comm%world,          &
+                           request,             &
                            comm%err)
         end subroutine mpi_integer_isend
 
@@ -76,12 +68,8 @@ module mpi_p2p
             integer,          intent(in)                :: source
             integer,          intent(in)                :: tag
             type(MPI_Request)                           :: request
-            integer                                    :: lb, ub
 
-            lb = lbound(data)
-            ub = ubound(data)
-
-            call MPI_Irecv(data(lb:ub),             &
+            call MPI_Irecv(data(1:size(data)),      &
                            size(data),              &
                            MPI_DOUBLE_PRECISION,    &
                            source,                  &
@@ -96,18 +84,14 @@ module mpi_p2p
             integer, intent(in)                :: source
             integer, intent(in)                :: tag
             type(MPI_Request)                  :: request
-            integer                           :: lb, ub
 
-            lb = lbound(data)
-            ub = ubound(data)
-
-            call MPI_Irecv(data(lb:ub), &
-                           size(data),  &
-                           MPI_INTEGER, &
-                           source,      &
-                           tag,         &
-                           comm%world,  &
-                           request,     &
+            call MPI_Irecv(data(1:size(data)),  &
+                           size(data),          &
+                           MPI_INTEGER,         &
+                           source,              &
+                           tag,                 &
+                           comm%world,          &
+                           request,             &
                            comm%err)
         end subroutine mpi_integer_irecv
 
@@ -119,12 +103,8 @@ module mpi_p2p
             double precision, intent(in) :: data(..)
             integer,          intent(in) :: dest
             integer,          intent(in) :: tag
-            integer                      :: lb, ub
 
-            lb = lbound(data)
-            ub = ubound(data)
-
-            call MPI_Send(data(lb:ub),          &
+            call MPI_Send(data(1:size(data)),   &
                           size(data),           &
                           MPI_DOUBLE_PRECISION, &
                           dest,                 &
@@ -137,17 +117,13 @@ module mpi_p2p
             integer, intent(in) :: data(..)
             integer, intent(in) :: dest
             integer, intent(in) :: tag
-            integer             :: lb, ub
 
-            lb = lbound(data)
-            ub = ubound(data)
-
-            call MPI_Send(data(lb:ub),  &
-                          size(data),   &
-                          MPI_INTEGER,  &
-                          dest,         &
-                          tag,          &
-                          comm%world,   &
+            call MPI_Send(data(1:size(data)),   &
+                          size(data),           &
+                          MPI_INTEGER,          &
+                          dest,                 &
+                          tag,                  &
+                          comm%world,           &
                           comm%err)
         end subroutine mpi_integer_send
 
@@ -157,12 +133,8 @@ module mpi_p2p
             integer,          intent(in)  :: source
             integer,          intent(in)  :: tag
             type(MPI_Status)              :: status
-            integer                       :: lb, ub
 
-            lb = lbound(data)
-            ub = ubound(data)
-
-            call MPI_Recv(data(lb:ub),          &
+            call MPI_Recv(data(1:size(data)),   &
                           size(data),           &
                           MPI_DOUBLE_PRECISION, &
                           source,               &
@@ -177,18 +149,14 @@ module mpi_p2p
             integer, intent(in)  :: source
             integer, intent(in)  :: tag
             type(MPI_Status)     :: status
-            integer              :: lb, ub
 
-            lb = lbound(data)
-            ub = ubound(data)
-
-            call MPI_Recv(data(lb:ub),  &
-                          size(data),   &
-                          MPI_INTEGER,  &
-                          source,       &
-                          tag,          &
-                          comm%world,   &
-                          status,       &
+            call MPI_Recv(data(1:size(data)),   &
+                          size(data),           &
+                          MPI_INTEGER,          &
+                          source,               &
+                          tag,                  &
+                          comm%world,           &
+                          status,               &
                           comm%err)
         end subroutine mpi_integer_recv
 

--- a/src/mpi/mpi_reverse.f90
+++ b/src/mpi/mpi_reverse.f90
@@ -407,19 +407,19 @@ module mpi_reverse
             type(sub_communicator), intent(inout) :: sub_comm
             type(MPI_Request)                     :: requests(2)
             type(MPI_Status)                      :: send_statuses(2)
-            integer                               :: lb, ub
+            integer                               :: lb(3), ub(3)
 
             lb = lbound(reo%lo_buffer)
             ub = ubound(reo%lo_buffer)
 
             ! send west buffer to east halo
-            call MPI_Isend(reo%lo_buffer(lb:ub),    &
-                           size(reo%lo_buffer),     &
-                           MPI_DOUBLE_PRECISION,    &
-                           reo%lo_rank,             &
-                           REVERSE_LO_TAG,          &
-                           sub_comm%comm,           &
-                           requests(1),             &
+            call MPI_Isend(reo%lo_buffer(lb(1):ub(1), lb(2):ub(2), lb(3):ub(3)),    &
+                           size(reo%lo_buffer),                                     &
+                           MPI_DOUBLE_PRECISION,                                    &
+                           reo%lo_rank,                                             &
+                           REVERSE_LO_TAG,                                          &
+                           sub_comm%comm,                                           &
+                           requests(1),                                             &
                            sub_comm%err)
 
             call mpi_check_for_error("in MPI_Isend of mpi_reverse::communicate_halo.")
@@ -428,13 +428,13 @@ module mpi_reverse
             ub = ubound(reo%hi_halo_buffer)
 
             ! receive west buffer to east halo (left to right)
-            call MPI_Recv(reo%hi_halo_buffer(lb:ub),    &
-                          size(reo%hi_halo_buffer),     &
-                          MPI_DOUBLE_PRECISION,         &
-                          reo%hi_rank,                  &
-                          REVERSE_LO_TAG,               &
-                          sub_comm%comm,                &
-                          MPI_STATUS_IGNORE,            &
+            call MPI_Recv(reo%hi_halo_buffer(lb(1):ub(1), lb(2):ub(2), lb(3):ub(3)),    &
+                          size(reo%hi_halo_buffer),                                     &
+                          MPI_DOUBLE_PRECISION,                                         &
+                          reo%hi_rank,                                                  &
+                          REVERSE_LO_TAG,                                               &
+                          sub_comm%comm,                                                &
+                          MPI_STATUS_IGNORE,                                            &
                           sub_comm%err)
 
             call mpi_check_for_error("in MPI_Recv of mpi_reverse::communicate_halo.")
@@ -443,13 +443,13 @@ module mpi_reverse
             ub = ubound(reo%hi_buffer)
 
             ! send east buffer to west halo
-            call MPI_Isend(reo%hi_buffer(lb:ub),    &
-                           size(reo%hi_buffer),     &
-                           MPI_DOUBLE_PRECISION,    &
-                           reo%hi_rank,             &
-                           REVERSE_HI_TAG,          &
-                           sub_comm%comm,           &
-                           request(2),              &
+            call MPI_Isend(reo%hi_buffer(lb(1):ub(1), lb(2):ub(2), lb(3):ub(3)),    &
+                           size(reo%hi_buffer),                                     &
+                           MPI_DOUBLE_PRECISION,                                    &
+                           reo%hi_rank,                                             &
+                           REVERSE_HI_TAG,                                          &
+                           sub_comm%comm,                                           &
+                           request(2),                                              &
                            sub_comm%err)
 
             call mpi_check_for_error("in MPI_Isend of mpi_reverse::communicate_halo.")
@@ -458,13 +458,13 @@ module mpi_reverse
             ub = ubound(reo%lo_halo_buffer)
 
             ! receive east buffer into west halo (right to left)
-            call MPI_Recv(reo%lo_halo_buffer,       &
-                          size(reo%lo_halo_buffer), &
-                          MPI_DOUBLE_PRECISION,     &
-                          reo%lo_rank,              &
-                          REVERSE_HI_TAG,           &
-                          sub_comm%comm,            &
-                          MPI_STATUS_IGNORE,        &
+            call MPI_Recv(reo%lo_halo_buffer(lb(1):ub(1), lb(2):ub(2), lb(3):ub(3)),    &
+                          size(reo%lo_halo_buffer),                                     &
+                          MPI_DOUBLE_PRECISION,                                         &
+                          reo%lo_rank,                                                  &
+                          REVERSE_HI_TAG,                                               &
+                          sub_comm%comm,                                                &
+                          MPI_STATUS_IGNORE,                                            &
                           sub_comm%err)
 
             call mpi_check_for_error("in MPI_Recv of mpi_reverse::communicate_halo.")

--- a/src/mpi/mpi_reverse.f90
+++ b/src/mpi/mpi_reverse.f90
@@ -1,7 +1,7 @@
 module mpi_reverse
     use mpi_communicator
     use mpi_layout
-    use mpi_utils, only : mpi_exit_on_error
+    use mpi_utils, only : mpi_exit_on_error, mpi_check_for_error
     implicit none
 
     private
@@ -287,6 +287,7 @@ module mpi_reverse
             double precision, intent(out) :: gs(box%lo(3):box%hi(3),   & ! 0:nz
                                                 box%lo(2):box%hi(2),   &
                                                 box%hlo(1):box%hhi(1))
+            integer                       :: slb, sub, rlb, rub
 
             if (.not. l_initialised_x) then
                 call initialise_reversing(x_reo, x_comm, 1)
@@ -297,15 +298,20 @@ module mpi_reverse
 
             call copy_to_buffer_in_x(gs)
 
-            call MPI_alltoallv(x_reo%send_buffer,       &
-                               x_reo%send_recv_count,   &
-                               x_reo%send_offset,       &
-                               MPI_DOUBLE_PRECISION,    &
-                               x_reo%recv_buffer,       &
-                               x_reo%send_recv_count,   &
-                               x_reo%recv_offset,       &
-                               MPI_DOUBLE_PRECISION,    &
-                               x_comm%comm,             &
+            slb = lbound(x_reo%send_buffer)
+            sub = ubound(x_reo%send_buffer)
+            rlb = lbound(x_reo%recv_buffer)
+            rub = ubound(x_reo%recv_buffer)
+
+            call MPI_Alltoallv(x_reo%send_buffer(slb:sub),              &
+                               x_reo%send_recv_count(1:x_comm%size),    &
+                               x_reo%send_offset(1:x_comm%size),        &
+                               MPI_DOUBLE_PRECISION,                    &
+                               x_reo%recv_buffer(rlb:rub),              &
+                               x_reo%send_recv_count(1:x_comm%size),    &
+                               x_reo%recv_offset(1:x_comm%size),        &
+                               MPI_DOUBLE_PRECISION,                    &
+                               x_comm%comm,                             &
                                x_comm%err)
 
             call copy_from_buffer_in_x(gs)
@@ -323,6 +329,7 @@ module mpi_reverse
             double precision, intent(out) :: gs(box%lo(3):box%hi(3),   & ! 0:nz
                                                 box%hlo(2):box%hhi(2), &
                                                 box%lo(1):box%hi(1))
+            integer                       :: slb, sub, rlb, rub
 
             if (.not. l_initialised_y) then
                 call initialise_reversing(y_reo, y_comm, 2)
@@ -333,15 +340,20 @@ module mpi_reverse
 
             call copy_to_buffer_in_y(gs)
 
-            call MPI_alltoallv(y_reo%send_buffer,       &
-                               y_reo%send_recv_count,   &
-                               y_reo%send_offset,       &
-                               MPI_DOUBLE_PRECISION,    &
-                               y_reo%recv_buffer,       &
-                               y_reo%send_recv_count,   &
-                               y_reo%recv_offset,       &
-                               MPI_DOUBLE_PRECISION,    &
-                               y_comm%comm,             &
+            slb = lbound(y_reo%send_buffer)
+            sub = ubound(y_reo%send_buffer)
+            rlb = lbound(y_reo%recv_buffer)
+            rub = ubound(y_reo%recv_buffer)
+
+            call MPI_Alltoallv(y_reo%send_buffer(slb:sub),              &
+                               y_reo%send_recv_count(1:y_comm%size),    &
+                               y_reo%send_offset(1:y_comm%size),        &
+                               MPI_DOUBLE_PRECISION,                    &
+                               y_reo%recv_buffer(rlb:rub),              &
+                               y_reo%send_recv_count(1:y_comm%size),    &
+                               y_reo%recv_offset(1:y_comm%size),        &
+                               MPI_DOUBLE_PRECISION,                    &
+                               y_comm%comm,                             &
                                y_comm%err)
 
             call copy_from_buffer_in_y(gs)
@@ -393,25 +405,76 @@ module mpi_reverse
         subroutine communicate_halo(reo, sub_comm)
             type(reorder_type),     intent(inout) :: reo
             type(sub_communicator), intent(inout) :: sub_comm
-            type(MPI_Request)                     :: request
+            type(MPI_Request)                     :: requests(2)
+            type(MPI_Status)                      :: send_statuses(2)
+            integer                               :: lb, ub
+
+            lb = lbound(reo%lo_buffer)
+            ub = ubound(reo%lo_buffer)
 
             ! send west buffer to east halo
-            call MPI_Isend(reo%lo_buffer, size(reo%lo_buffer), MPI_DOUBLE_PRECISION, &
-                            reo%lo_rank, REVERSE_LO_TAG, sub_comm%comm, request, sub_comm%err)
-            call MPI_Request_free(request)
+            call MPI_Isend(reo%lo_buffer(lb:ub),    &
+                           size(reo%lo_buffer),     &
+                           MPI_DOUBLE_PRECISION,    &
+                           reo%lo_rank,             &
+                           REVERSE_LO_TAG,          &
+                           sub_comm%comm,           &
+                           requests(1),             &
+                           sub_comm%err)
+
+            call mpi_check_for_error("in MPI_Isend of mpi_reverse::communicate_halo.")
+
+            lb = lbound(reo%hi_halo_buffer)
+            ub = ubound(reo%hi_halo_buffer)
 
             ! receive west buffer to east halo (left to right)
-            call MPI_Recv(reo%hi_halo_buffer, size(reo%hi_halo_buffer), MPI_DOUBLE_PRECISION, &
-                          reo%hi_rank, REVERSE_LO_TAG, sub_comm%comm, MPI_STATUS_IGNORE, sub_comm%err)
+            call MPI_Recv(reo%hi_halo_buffer(lb:ub),    &
+                          size(reo%hi_halo_buffer),     &
+                          MPI_DOUBLE_PRECISION,         &
+                          reo%hi_rank,                  &
+                          REVERSE_LO_TAG,               &
+                          sub_comm%comm,                &
+                          MPI_STATUS_IGNORE,            &
+                          sub_comm%err)
+
+            call mpi_check_for_error("in MPI_Recv of mpi_reverse::communicate_halo.")
+
+            lb = lbound(reo%hi_buffer)
+            ub = ubound(reo%hi_buffer)
 
             ! send east buffer to west halo
-            call MPI_Isend(reo%hi_buffer, size(reo%hi_buffer), MPI_DOUBLE_PRECISION, &
-                           reo%hi_rank, REVERSE_HI_TAG, sub_comm%comm, request, sub_comm%err)
-            call MPI_Request_free(request)
+            call MPI_Isend(reo%hi_buffer(lb:ub),    &
+                           size(reo%hi_buffer),     &
+                           MPI_DOUBLE_PRECISION,    &
+                           reo%hi_rank,             &
+                           REVERSE_HI_TAG,          &
+                           sub_comm%comm,           &
+                           request(2),              &
+                           sub_comm%err)
+
+            call mpi_check_for_error("in MPI_Isend of mpi_reverse::communicate_halo.")
+
+            lb = lbound(reo%lo_halo_buffer)
+            ub = ubound(reo%lo_halo_buffer)
 
             ! receive east buffer into west halo (right to left)
-            call MPI_Recv(reo%lo_halo_buffer, size(reo%lo_halo_buffer), MPI_DOUBLE_PRECISION, &
-                          reo%lo_rank, REVERSE_HI_TAG, sub_comm%comm, MPI_STATUS_IGNORE, sub_comm%err)
+            call MPI_Recv(reo%lo_halo_buffer,       &
+                          size(reo%lo_halo_buffer), &
+                          MPI_DOUBLE_PRECISION,     &
+                          reo%lo_rank,              &
+                          REVERSE_HI_TAG,           &
+                          sub_comm%comm,            &
+                          MPI_STATUS_IGNORE,        &
+                          sub_comm%err)
+
+            call mpi_check_for_error("in MPI_Recv of mpi_reverse::communicate_halo.")
+
+            call MPI_Waitall(2,                 &
+                            requests,           &
+                            send_statuses,      &
+                            comm%err)
+
+            call mpi_check_for_error("in MPI_Waitall of mpi_reverse::communicate_halo.")
 
         end subroutine communicate_halo
 

--- a/src/mpi/mpi_tags.f90
+++ b/src/mpi/mpi_tags.f90
@@ -11,14 +11,23 @@ module mpi_tags
                            MPI_SOUTHWEST = 7, &
                            MPI_SOUTHEAST = 8
 
-    integer, parameter :: NEIGHBOUR_TAG(8) = (/MPI_SOUTH,       &   ! north maps to south
-                                               MPI_NORTH,       &   ! south maps to north
-                                               MPI_EAST,        &   ! west maps to east
-                                               MPI_WEST,        &   ! east maps to west
-                                               MPI_SOUTHEAST,   &   ! northwest maps to southeast
-                                               MPI_SOUTHWEST,   &   ! northeast maps to southwest
-                                               MPI_NORTHEAST,   &   ! southwest maps to northeast
-                                               MPI_NORTHWEST/)      ! southeast maps to northwest
+    integer, parameter :: SEND_NEIGHBOUR_TAG(8) = (/MPI_SOUTH,      &   ! north maps to south
+                                                    MPI_NORTH,      &   ! south maps to north
+                                                    MPI_EAST,       &   ! west maps to east
+                                                    MPI_WEST,       &   ! east maps to west
+                                                    MPI_SOUTHEAST,  &   ! northwest maps to southeast
+                                                    MPI_SOUTHWEST,  &   ! northeast maps to southwest
+                                                    MPI_NORTHEAST,  &   ! southwest maps to northeast
+                                                    MPI_NORTHWEST/)
+
+    integer, parameter :: RECV_NEIGHBOUR_TAG(8) = (/MPI_NORTH,      &
+                                                    MPI_SOUTH,      &
+                                                    MPI_WEST,       &
+                                                    MPI_EAST,       &
+                                                    MPI_NORTHWEST,  &
+                                                    MPI_NORTHEAST,  &
+                                                    MPI_SOUTHWEST,  &
+                                                    MPI_SOUTHEAST/)
 
     integer, parameter :: REVERSE_LO_TAG = 3000, &
                           REVERSE_HI_TAG = 3001

--- a/src/mpi/mpi_timer.f90
+++ b/src/mpi/mpi_timer.f90
@@ -263,17 +263,16 @@ module mpi_timer
         function get_statistics(op) result(buffer)
             type(MPI_Op), intent(in) :: op
             double precision         :: buffer(size(timings))
-            integer                  :: lb, ub
+            integer                  :: buf_size
 
             buffer = timings(:)%wall_time
 
-            lb = lbound(buffer)
-            ub = ubound(buffer)
+            buf_size = size(timings)
 
             if (comm%rank == comm%master) then
                 call MPI_Reduce(MPI_IN_PLACE,           &
-                                buffer(lb:ub),          &
-                                size(timings),          &
+                                buffer(1:buf_size),     &
+                                buf_size,               &
                                 MPI_DOUBLE_PRECISION,   &
                                 op,                     &
                                 comm%master,            &
@@ -281,9 +280,9 @@ module mpi_timer
                                 comm%err)
 
             else
-                call MPI_Reduce(buffer(lb:ub),          &
-                                buffer(lb:ub),          &
-                                size(timings),          &
+                call MPI_Reduce(buffer(1:buf_size),     &
+                                buffer(1:buf_size),     &
+                                buf_size,               &
                                 MPI_DOUBLE_PRECISION,   &
                                 op,                     &
                                 comm%master,            &

--- a/src/mpi/mpi_timer.f90
+++ b/src/mpi/mpi_timer.f90
@@ -262,17 +262,33 @@ module mpi_timer
 
         function get_statistics(op) result(buffer)
             type(MPI_Op), intent(in) :: op
-            double precision :: buffer(size(timings))
+            double precision         :: buffer(size(timings))
+            integer                  :: lb, ub
 
             buffer = timings(:)%wall_time
 
+            lb = lbound(buffer)
+            ub = ubound(buffer)
+
             if (comm%rank == comm%master) then
-                call MPI_Reduce(MPI_IN_PLACE, buffer, size(timings), MPI_DOUBLE_PRECISION, &
-                                op, comm%master, comm%world, comm%err)
+                call MPI_Reduce(MPI_IN_PLACE,           &
+                                buffer(lb:ub),          &
+                                size(timings),          &
+                                MPI_DOUBLE_PRECISION,   &
+                                op,                     &
+                                comm%master,            &
+                                comm%world,             &
+                                comm%err)
 
             else
-                call MPI_Reduce(buffer, buffer, size(timings), MPI_DOUBLE_PRECISION, &
-                                op, comm%master, comm%world, comm%err)
+                call MPI_Reduce(buffer(lb:ub),          &
+                                buffer(lb:ub),          &
+                                size(timings),          &
+                                MPI_DOUBLE_PRECISION,   &
+                                op,                     &
+                                comm%master,            &
+                                comm%world,             &
+                                comm%err)
             endif
 
         end function get_statistics

--- a/src/mpi/mpi_utils.f90
+++ b/src/mpi/mpi_utils.f90
@@ -23,34 +23,37 @@ module mpi_utils
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-        subroutine mpi_check_for_message(tag, recv_size, source)
-            integer, intent(out) :: recv_size, tag, source
+        subroutine mpi_check_for_message(source, tag, recv_size)
+            integer, intent(in)  :: source, tag
+            integer, intent(out) :: recv_size
             type(MPI_Status)     :: status
 
             status%MPI_SOURCE = -1
             status%MPI_TAG = -1
             status%MPI_ERROR = 0
 
-            call MPI_probe(MPI_ANY_SOURCE,  &
-                           MPI_ANY_TAG,     &
+            call MPI_probe(source,          &
+                           tag,             &
                            comm%cart,       &
                            status,          &
                            comm%err)
 
-            call mpi_check_for_error("in MPI_probe of mpi_utils::mpi_check_for_message.")
-
-            source = status%MPI_SOURCE
-            tag = status%MPI_TAG
+            call mpi_check_for_error(&
+                "in MPI_probe of mpi_utils::mpi_check_for_message.")
 
             comm%err = status%MPI_ERROR
-            call mpi_check_for_error("in MPI_Status of mpi_utils::mpi_check_for_message.")
+            call mpi_check_for_error(&
+                "in MPI_Status of mpi_utils::mpi_check_for_message.")
 
             recv_size = 0
             call MPI_get_count(status, MPI_DOUBLE_PRECISION, recv_size, comm%err)
 
-            call mpi_check_for_error("in MPI_get_count of mpi_utils::mpi_check_for_message.")
+            call mpi_check_for_error(&
+                "in MPI_get_count of mpi_utils::mpi_check_for_message.")
 
         end subroutine mpi_check_for_message
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         subroutine mpi_check_for_error(msg)
             character(*), intent(in) :: msg

--- a/src/netcdf/netcdf_writer.f90
+++ b/src/netcdf/netcdf_writer.f90
@@ -40,6 +40,27 @@ module netcdf_writer
 
     contains
 
+        subroutine set_independent_write(ncid, varid, l_serial)
+            integer,           intent(in) :: ncid
+            integer,           intent(in) :: varid
+            logical, optional, intent(in) :: l_serial
+            logical                       :: l_parallel
+
+            l_parallel = (comm%size > 1)
+
+            if (present(l_serial)) then
+                l_parallel = .not. l_serial
+            endif
+
+            if (l_parallel) then
+                ncerr = nf90_var_par_access(ncid, varid, NF90_INDEPENDENT)
+                call check_netcdf_error("Failed to set independent.")
+            endif
+
+        end subroutine set_independent_write
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
         subroutine set_collective_write(ncid, varid, l_serial)
             integer,           intent(in) :: ncid
             integer,           intent(in) :: varid
@@ -366,15 +387,15 @@ module netcdf_writer
             call write_netcdf_dataset(ncid, dimids(2), z_axis)
         end subroutine write_netcdf_axis_2d
 
-        subroutine write_netcdf_axis_3d(ncid, dimids, origin, dx, ngps)
-            integer,          intent(in) :: ncid
-            double precision, intent(in) :: origin(3), dx(3)
-            integer,          intent(in) :: dimids(3), ngps(3)
-            integer                      :: i
-            double precision             :: x_axis(0:ngps(1)-1)
-            double precision             :: y_axis(0:ngps(2)-1)
-            double precision             :: z_axis(0:ngps(3)-1)
-
+        subroutine write_netcdf_axis_3d(ncid, dimids, origin, dx, ngps, start, cnt)
+            integer,           intent(in) :: ncid
+            double precision,  intent(in) :: origin(3), dx(3)
+            integer,           intent(in) :: dimids(3), ngps(3)
+            integer, optional, intent(in) :: start(3), cnt(3)
+            integer                       :: i
+            double precision              :: x_axis(0:ngps(1)-1)
+            double precision              :: y_axis(0:ngps(2)-1)
+            double precision              :: z_axis(0:ngps(3)-1)
 
             do i = 0, ngps(1)-1
                 x_axis(i) = origin(1) + dble(i) * dx(1)
@@ -388,9 +409,13 @@ module netcdf_writer
                 z_axis(i) = origin(3) + dble(i) * dx(3)
             enddo
 
-            call write_netcdf_dataset(ncid, dimids(1), x_axis)
-            call write_netcdf_dataset(ncid, dimids(2), y_axis)
-            call write_netcdf_dataset(ncid, dimids(3), z_axis)
+            call write_netcdf_dataset(ncid, dimids(1), x_axis, &
+                                      start=(/start(1)/), cnt=(/cnt(1)/))
+            call write_netcdf_dataset(ncid, dimids(2), y_axis, &
+                                      start=(/start(2)/), cnt=(/cnt(2)/))
+            call write_netcdf_dataset(ncid, dimids(3), z_axis, &
+                                      start=(/start(3)/), cnt=(/cnt(3)/))
+
         end subroutine write_netcdf_axis_3d
 
         subroutine write_netcdf_info(ncid, version_tag, file_type, cf_version)

--- a/unit-tests/2d/test_ellipse_merge_1.f90
+++ b/unit-tests/2d/test_ellipse_merge_1.f90
@@ -58,6 +58,7 @@ program test_ellipse_multi_merge_1
             parcels%volume(1) = a1b1 * pi
             parcels%B(1, 1) = a1b1
             parcels%B(2, 1) = zero
+            parcels%vorticity(1) = zero
             parcels%buoyancy(1) = 1.5d0
 #ifndef ENABLE_DRY_MODE
             parcels%humidity(1) = 1.3d0
@@ -68,6 +69,7 @@ program test_ellipse_multi_merge_1
             parcels%volume(2) = a2b2 * pi
             parcels%B(1, 2) = a2b2
             parcels%B(2, 2) = zero
+            parcels%vorticity(2) = zero
             parcels%buoyancy(2) = 1.8d0
 #ifndef ENABLE_DRY_MODE
             parcels%humidity(2) = 1.2d0
@@ -78,6 +80,7 @@ program test_ellipse_multi_merge_1
             parcels%volume(3) = a2b2 * pi
             parcels%B(1, 3) = a2b2
             parcels%B(2, 3) = zero
+            parcels%vorticity(3) = zero
             parcels%buoyancy(3) = 1.4d0
 #ifndef ENABLE_DRY_MODE
             parcels%humidity(3) = 1.1d0
@@ -88,6 +91,7 @@ program test_ellipse_multi_merge_1
             parcels%volume(4) = a2b2 * pi
             parcels%B(1, 4) = a2b2
             parcels%B(2, 4) = zero
+            parcels%vorticity(4) = zero
             parcels%buoyancy(4) = 1.7d0
 #ifndef ENABLE_DRY_MODE
             parcels%humidity(4) = 1.0d0
@@ -98,6 +102,7 @@ program test_ellipse_multi_merge_1
             parcels%volume(5) = a2b2 * pi
             parcels%B(1, 5) = a2b2
             parcels%B(2, 5) = zero
+            parcels%vorticity(5) = zero
             parcels%buoyancy(5) = 1.5d0
 #ifndef ENABLE_DRY_MODE
             parcels%humidity(5) = 1.4d0

--- a/unit-tests/2d/test_ellipse_merge_2.f90
+++ b/unit-tests/2d/test_ellipse_merge_2.f90
@@ -62,6 +62,7 @@ program test_ellipse_multi_merge_2
             parcels%volume(1) = a1b1 * pi
             parcels%B(1, 1) = a1b1
             parcels%B(2, 1) = zero
+            parcels%vorticity(1) = zero
             parcels%buoyancy(1) = 1.5d0
 #ifndef ENABLE_DRY_MODE
             parcels%humidity(1) = 1.3d0
@@ -72,6 +73,7 @@ program test_ellipse_multi_merge_2
             parcels%volume(2) = a2b2 * pi
             parcels%B(1, 2) = a2b2
             parcels%B(2, 2) = zero
+            parcels%vorticity(2) = zero
             parcels%buoyancy(2) = 1.8d0
 #ifndef ENABLE_DRY_MODE
             parcels%humidity(2) = 1.2d0
@@ -82,6 +84,7 @@ program test_ellipse_multi_merge_2
             parcels%volume(3) = a2b2 * pi
             parcels%B(1, 3) = a2b2
             parcels%B(2, 3) = zero
+            parcels%vorticity(3) = zero
             parcels%buoyancy(3) = 1.4d0
 #ifndef ENABLE_DRY_MODE
             parcels%humidity(3) = 1.1d0

--- a/unit-tests/2d/test_ellipse_merge_3.f90
+++ b/unit-tests/2d/test_ellipse_merge_3.f90
@@ -55,6 +55,12 @@ program test_ellipse_multi_merge_3
 
             d = (dsqrt(a1b1) + dsqrt(a2b2)) * f12 * dsqrt(two)
 
+            parcels%vorticity = zero
+            parcels%buoyancy = zero
+#ifndef ENABLE_DRY_MODE
+            parcels%humidity = zero
+#endif
+
             n_parcels = 3
             parcels%position(1, 1) = 1.5d0
             parcels%position(2, 1) = 0.2d0

--- a/unit-tests/2d/test_ellipse_merge_4.f90
+++ b/unit-tests/2d/test_ellipse_merge_4.f90
@@ -50,6 +50,13 @@ program test_ellipse_multi_merge_4
 
         subroutine parcel_setup
             n_parcels = 3
+
+            parcels%vorticity = zero
+            parcels%buoyancy = zero
+#ifndef ENABLE_DRY_MODE
+            parcels%humidity = zero
+#endif
+
             parcels%position(1, 1) = -0.5d0
             parcels%position(2, 1) = zero
             parcels%volume(1) = 0.25d0 * pi

--- a/unit-tests/3d/Makefile.am
+++ b/unit-tests/3d/Makefile.am
@@ -51,7 +51,7 @@ unittests_PROGRAMS = 				\
 	test_mpi_parcel_unpack			\
 	test_mpi_parcel_read			\
 	test_mpi_parcel_read_rejection		\
-	test_mpi_parcel_halo_swap		\
+	test_mpi_parcel_communicate		\
 	test_mpi_parcel_split			\
 	test_mpi_fft				\
 	test_mpi_dst				\
@@ -170,8 +170,8 @@ test_mpi_parcel_read_LDADD = libcombi.la
 test_mpi_parcel_read_rejection_SOURCES = test_mpi_parcel_read_rejection.f90
 test_mpi_parcel_read_rejection_LDADD = libcombi.la
 
-test_mpi_parcel_halo_swap_SOURCES = test_mpi_parcel_halo_swap.f90
-test_mpi_parcel_halo_swap_LDADD = libcombi.la
+test_mpi_parcel_communicate_SOURCES = test_mpi_parcel_communicate.f90
+test_mpi_parcel_communicate_LDADD = libcombi.la
 
 test_mpi_parcel_split_SOURCES = test_mpi_parcel_split.f90
 test_mpi_parcel_split_LDADD = libcombi.la

--- a/unit-tests/3d/test_mpi_diffx.f90
+++ b/unit-tests/3d/test_mpi_diffx.f90
@@ -29,9 +29,9 @@ program test_mpi_diffx
     lower = (/-pi, -pi, -pi/)
     extent = (/twopi, twopi, twopi/)
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     allocate(fp(box%hlo(3):box%hhi(3), box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))
     allocate(fs(box%lo(3):box%hi(3), box%lo(2):box%hi(2), box%lo(1):box%hi(1)))

--- a/unit-tests/3d/test_mpi_diffy.f90
+++ b/unit-tests/3d/test_mpi_diffy.f90
@@ -29,9 +29,9 @@ program test_mpi_diffy
     lower = (/-pi, -pi, -pi/)
     extent = (/twopi, twopi, twopi/)
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     allocate(fp(box%hlo(3):box%hhi(3), box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))
     allocate(fs(box%lo(3):box%hi(3), box%lo(2):box%hi(2), box%lo(1):box%hi(1)))

--- a/unit-tests/3d/test_mpi_diffz0.f90
+++ b/unit-tests/3d/test_mpi_diffz0.f90
@@ -1,3 +1,4 @@
+
 ! =============================================================================
 !                       Test subroutine diffz
 !
@@ -36,9 +37,9 @@ program test_mpi_diffz0
     lower  = (/zero, zero, zero/)
     extent =  (/pi, twopi, two * twopi/)
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     allocate(fp(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))
     allocate(dp(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))

--- a/unit-tests/3d/test_mpi_diffz1.f90
+++ b/unit-tests/3d/test_mpi_diffz1.f90
@@ -37,9 +37,10 @@ program test_mpi_diffz1
     lower  = (/zero, zero, zero/)
     extent =  (/pi, pi, pi/)
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
-    call mpi_layout_init(lower, extent, nx, ny, nz)
 
     allocate(fp(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))
     allocate(dp(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))

--- a/unit-tests/3d/test_mpi_diffz2.f90
+++ b/unit-tests/3d/test_mpi_diffz2.f90
@@ -36,9 +36,9 @@ program test_mpi_diffz2
     lower  = (/zero, zero, zero/)
     extent =  (/twopi, twopi, pi/)
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     allocate(fp(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))
     allocate(dp(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))

--- a/unit-tests/3d/test_mpi_diffz3.f90
+++ b/unit-tests/3d/test_mpi_diffz3.f90
@@ -36,9 +36,9 @@ program test_mpi_diffz3
     lower  = (/zero, zero, -f12 * pi/)
     extent =  (/twopi, twopi, pi/)
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     allocate(fp(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))
     allocate(dp(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))

--- a/unit-tests/3d/test_mpi_diffz4.f90
+++ b/unit-tests/3d/test_mpi_diffz4.f90
@@ -36,9 +36,9 @@ program test_mpi_diffz4
     lower  = (/zero, zero, -f12 * pi/)
     extent =  (/twopi, twopi, pi/)
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     allocate(fp(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))
     allocate(dp(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))

--- a/unit-tests/3d/test_mpi_diffz5.f90
+++ b/unit-tests/3d/test_mpi_diffz5.f90
@@ -36,9 +36,9 @@ program test_mpi_diffz5
     lower  = (/zero, zero, -f12 * pi/)
     extent =  (/twopi, twopi, pi/)
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     allocate(fp(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))
     allocate(dp(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))

--- a/unit-tests/3d/test_mpi_dst.f90
+++ b/unit-tests/3d/test_mpi_dst.f90
@@ -30,9 +30,9 @@ program test_mpi_dst
     lower = (/-pi, f12 * pi, zero/)
     extent = (/twopi, two * twopi, four * twopi/)
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     allocate(fp1(box%hlo(3):box%hhi(3), box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))
     allocate(fp2(box%hlo(3):box%hhi(3), box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))

--- a/unit-tests/3d/test_mpi_fft.f90
+++ b/unit-tests/3d/test_mpi_fft.f90
@@ -30,9 +30,9 @@ program test_mpi_fft_3d
     lower = (/-pi, f12 * pi, zero/)
     extent = (/twopi, two * twopi, four * twopi/)
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     allocate(fp1(box%hlo(3):box%hhi(3), box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))
     allocate(fp2(box%hlo(3):box%hhi(3), box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))

--- a/unit-tests/3d/test_mpi_fft0.f90
+++ b/unit-tests/3d/test_mpi_fft0.f90
@@ -30,9 +30,9 @@ program test_mpi_fft0
     lower = (/-pi, f12 * pi, zero/)
     extent = (/twopi, two * twopi, four * twopi/)
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     allocate(fp1(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))
     allocate(fp2(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))

--- a/unit-tests/3d/test_mpi_fft1.f90
+++ b/unit-tests/3d/test_mpi_fft1.f90
@@ -30,9 +30,9 @@ program test_mpi_fft1
     lower = (/-pi, f12 * pi, zero/)
     extent = (/twopi, two * twopi, four * twopi/)
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     allocate(fp1(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))
     allocate(fp2(-1:nz+1, box%hlo(2):box%hhi(2), box%hlo(1):box%hhi(1)))

--- a/unit-tests/3d/test_mpi_field_diagnostics.f90
+++ b/unit-tests/3d/test_mpi_field_diagnostics.f90
@@ -8,7 +8,7 @@ program test_mpi_field_diagnostics
     use mpi_layout
     use fields
     use field_diagnostics
-    use parameters, only : lower, update_parameters, extent, nx, ny, nz, vcell, vcelli, ngrid
+    use parameters, only : lower, update_parameters, extent, nx, ny, nz, vcell, vcelli, ncell
     use mpi_timer
     implicit none
 
@@ -26,9 +26,10 @@ program test_mpi_field_diagnostics
     lower  = zero
     extent =  one
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
-    ! calls mpi_layout_init internally
     call field_alloc
 
     volg = vcell + one
@@ -45,7 +46,7 @@ program test_mpi_field_diagnostics
         passed = (passed .and. (field_stats(IDX_MIN_NPAR) == one))
         passed = (passed .and. (field_stats(IDX_AVG_NPAR) == one))
         passed = (passed .and. (field_stats(IDX_AVG_NSPAR) == one))
-        passed = (passed .and. (field_stats(IDX_KEG) == 0.375d0 * dble(ngrid) * (vcell + one)))
+        passed = (passed .and. dabs(field_stats(IDX_KEG) - 0.375d0 * dble(ncell) * (vcell + one)) < 1.0e-14)
     endif
 
     call mpi_comm_finalise

--- a/unit-tests/3d/test_mpi_field_interior_accumulate.f90
+++ b/unit-tests/3d/test_mpi_field_interior_accumulate.f90
@@ -15,7 +15,7 @@ program test_field_interior_accumulate
     use field_mpi
     implicit none
 
-    integer, parameter            :: nx = 10, ny = 10, nz = 0
+    integer, parameter            :: nx = 10, ny = 10, nz = 1
     double precision, parameter   :: lower(3) = (/zero, zero, zero/)
     double precision, parameter   :: extent(3) = (/one, one, one/)
     double precision, allocatable :: values(:, :, :)

--- a/unit-tests/3d/test_mpi_gradient_correction_3d.f90
+++ b/unit-tests/3d/test_mpi_gradient_correction_3d.f90
@@ -54,6 +54,8 @@ program test_mpi_gradient_correction_3d
     lower  = (/zero, zero, zero/)
     extent = (/one, one, one/)
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
     call field_default
@@ -96,7 +98,7 @@ program test_mpi_gradient_correction_3d
         call apply_reflective_bc(parcels%position(:, n), parcels%B(:, n))
     enddo
 
-    call parcel_halo_swap
+    call parcel_communicate
 
     volg = zero
 

--- a/unit-tests/3d/test_mpi_grid2par.f90
+++ b/unit-tests/3d/test_mpi_grid2par.f90
@@ -34,6 +34,8 @@ program test_mpi_grid2par
 
     call register_timer('grid2par', grid2par_timer)
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
     call field_alloc

--- a/unit-tests/3d/test_mpi_laplace_correction_3d.f90
+++ b/unit-tests/3d/test_mpi_laplace_correction_3d.f90
@@ -55,6 +55,8 @@ program test_mpi_laplace_correction_3d
     lower  = (/zero, zero, zero/)
     extent = (/one, one, one/)
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
     call field_default
@@ -100,7 +102,7 @@ program test_mpi_laplace_correction_3d
         call apply_reflective_bc(parcels%position(:, n), parcels%B(:, n))
     enddo
 
-    call parcel_halo_swap
+    call parcel_communicate
 
     volg = zero
 

--- a/unit-tests/3d/test_mpi_nearest_1.f90
+++ b/unit-tests/3d/test_mpi_nearest_1.f90
@@ -37,9 +37,9 @@ program test_mpi_nearest_1
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_10.f90
+++ b/unit-tests/3d/test_mpi_nearest_10.f90
@@ -38,9 +38,9 @@ program test_mpi_nearest_10
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_11.f90
+++ b/unit-tests/3d/test_mpi_nearest_11.f90
@@ -38,9 +38,9 @@ program test_mpi_nearest_11
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_12.f90
+++ b/unit-tests/3d/test_mpi_nearest_12.f90
@@ -39,9 +39,9 @@ program test_mpi_nearest_12
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_13.f90
+++ b/unit-tests/3d/test_mpi_nearest_13.f90
@@ -39,9 +39,9 @@ program test_mpi_nearest_13
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_14.f90
+++ b/unit-tests/3d/test_mpi_nearest_14.f90
@@ -39,9 +39,9 @@ program test_mpi_nearest_14
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_15.f90
+++ b/unit-tests/3d/test_mpi_nearest_15.f90
@@ -39,9 +39,9 @@ program test_mpi_nearest_15
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_16.f90
+++ b/unit-tests/3d/test_mpi_nearest_16.f90
@@ -39,9 +39,9 @@ program test_mpi_nearest_16
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_17.f90
+++ b/unit-tests/3d/test_mpi_nearest_17.f90
@@ -39,9 +39,9 @@ program test_mpi_nearest_17
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_18.f90
+++ b/unit-tests/3d/test_mpi_nearest_18.f90
@@ -39,9 +39,9 @@ program test_mpi_nearest_18
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_19.f90
+++ b/unit-tests/3d/test_mpi_nearest_19.f90
@@ -39,9 +39,9 @@ program test_mpi_nearest_19
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_2.f90
+++ b/unit-tests/3d/test_mpi_nearest_2.f90
@@ -37,9 +37,9 @@ program test_mpi_nearest_2
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_20.f90
+++ b/unit-tests/3d/test_mpi_nearest_20.f90
@@ -85,9 +85,9 @@ program test_mpi_nearest_20
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_3.f90
+++ b/unit-tests/3d/test_mpi_nearest_3.f90
@@ -37,9 +37,9 @@ program test_mpi_nearest_3
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_4.f90
+++ b/unit-tests/3d/test_mpi_nearest_4.f90
@@ -37,9 +37,9 @@ program test_mpi_nearest_4
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_5.f90
+++ b/unit-tests/3d/test_mpi_nearest_5.f90
@@ -38,9 +38,9 @@ program test_mpi_nearest_5
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_6.f90
+++ b/unit-tests/3d/test_mpi_nearest_6.f90
@@ -38,9 +38,9 @@ program test_mpi_nearest_6
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_7.f90
+++ b/unit-tests/3d/test_mpi_nearest_7.f90
@@ -38,9 +38,9 @@ program test_mpi_nearest_7
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_8.f90
+++ b/unit-tests/3d/test_mpi_nearest_8.f90
@@ -38,9 +38,9 @@ program test_mpi_nearest_8
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_nearest_9.f90
+++ b/unit-tests/3d/test_mpi_nearest_9.f90
@@ -38,9 +38,9 @@ program test_mpi_nearest_9
     ! vmin = vcell / parcel%min_vratio
     parcel%min_vratio = 8.0d0
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     call parcel_alloc(max_num_parcels)
 

--- a/unit-tests/3d/test_mpi_parcel_communicate.f90
+++ b/unit-tests/3d/test_mpi_parcel_communicate.f90
@@ -4,7 +4,7 @@
 !   This unit test checks parcel halo swap. Each MPI rank sends comm%rank+1
 !   parcels to each of its neighbours.
 ! =============================================================================
-program test_mpi_parcel_halo_swap
+program test_mpi_parcel_communicate
     use constants, only : zero, one, f12
     use unit_test
     use mpi_communicator
@@ -30,6 +30,8 @@ program test_mpi_parcel_halo_swap
     nz = 32
     lower  = zero
     extent =  one
+
+    call mpi_layout_init(lower, extent, nx, ny, nz)
 
     call update_parameters
 
@@ -96,7 +98,7 @@ program test_mpi_parcel_halo_swap
     parcels%vorticity(:, 1:n_parcels) = comm%rank + 1
     parcels%buoyancy(1:n_parcels) = comm%rank + 1
 
-    call parcel_halo_swap
+    call parcel_communicate
 
     n_total_verify = n_parcels
     call mpi_blocking_reduce(n_total_verify, MPI_SUM)
@@ -147,4 +149,4 @@ program test_mpi_parcel_halo_swap
 
     call mpi_comm_finalise
 
-end program test_mpi_parcel_halo_swap
+end program test_mpi_parcel_communicate

--- a/unit-tests/3d/test_mpi_parcel_correction_3d.f90
+++ b/unit-tests/3d/test_mpi_parcel_correction_3d.f90
@@ -58,6 +58,8 @@ program test_parcel_correction_3d
     lower  = (/zero, zero, zero/)
     extent = (/one, one, one/)
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
     call field_default
@@ -103,7 +105,7 @@ program test_parcel_correction_3d
         call apply_reflective_bc(parcels%position(:, n), parcels%B(:, n))
     enddo
 
-    call parcel_halo_swap
+    call parcel_communicate
 
     volg = zero
 

--- a/unit-tests/3d/test_mpi_parcel_diagnostics.f90
+++ b/unit-tests/3d/test_mpi_parcel_diagnostics.f90
@@ -6,7 +6,6 @@ program test_mpi_parcel_diagnostics
     use unit_test
     use mpi_communicator
     use mpi_layout
-    use fields, only : field_alloc
     use parcel_container
     use parcel_diagnostics
     use parameters, only : lower, update_parameters, extent, nx, ny, nz, vcell, dx, set_vmin
@@ -30,13 +29,12 @@ program test_mpi_parcel_diagnostics
     lower  = zero
     extent =  one
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
     ! set to make all parcels smaller than vmin
     call set_vmin(vcell)
-
-    ! calls mpi_layout_init internally
-    call field_alloc
 
     n_parcels = n_per_dim ** 3 * nz * (box%hi(2)-box%lo(2)+1) * (box%hi(1)-box%lo(1)+1)
     n_total = n_per_dim ** 3 * nz * ny * nx

--- a/unit-tests/3d/test_mpi_parcel_init_3d.f90
+++ b/unit-tests/3d/test_mpi_parcel_init_3d.f90
@@ -49,6 +49,8 @@ program test_mpi_parcel_init_3d
     call register_timer('parcel init', init_timer)
     call register_timer('par2grid', par2grid_timer)
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
     call field_default

--- a/unit-tests/3d/test_mpi_parcel_read_rejection.f90
+++ b/unit-tests/3d/test_mpi_parcel_read_rejection.f90
@@ -13,7 +13,6 @@ program test_mpi_parcel_read_rejection
     use parcel_netcdf
     use mpi_communicator
     use mpi_layout
-    use fields, only : field_alloc
     use parameters, only : lower, update_parameters, extent, nx, ny, nz, dx, max_num_parcels
     use mpi_timer
     implicit none
@@ -54,10 +53,9 @@ program test_mpi_parcel_read_rejection
     parcel%min_vratio = 40.d0
     parcel%size_factor = 1
 
-    call update_parameters
+    call mpi_layout_init(lower, extent, nx, ny, nz)
 
-    ! calls mpi_layout_init internally
-    call field_alloc
+    call update_parameters
 
     call register_timer('parcel I/O', parcel_io_timer)
 

--- a/unit-tests/3d/test_mpi_parcel_split.f90
+++ b/unit-tests/3d/test_mpi_parcel_split.f90
@@ -11,7 +11,6 @@ program test_mpi_parcel_split
     use unit_test
     use mpi_communicator
     use mpi_layout
-    use fields, only : field_alloc
     use parcel_container
     use parcel_mpi
     use parameters, only : lower, update_parameters, extent, nx, ny, nz, dx, vcell, set_vmax
@@ -39,12 +38,11 @@ program test_mpi_parcel_split
     lower  = zero
     extent = four
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
     call set_vmax(f14 * vcell)
-
-    ! calls mpi_layout_init internally
-    call field_alloc
 
     n_parcels = 2 * (box%hi(2) - box%lo(2) + 1) + 2 * (box%hi(1) - box%lo(1) + 1)
     n_total = 2 * n_parcels

--- a/unit-tests/3d/test_mpi_reverse_x.f90
+++ b/unit-tests/3d/test_mpi_reverse_x.f90
@@ -31,9 +31,9 @@ program test_mpi_reverse_x
     lower = (/zero, zero, zero/)
     extent = (/one, one, one/)
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     allocate(fp(box%lo(3):box%hi(3), box%lo(2):box%hi(2), box%lo(1):box%hi(1)))
     allocate(gp(box%lo(3):box%hi(3), box%lo(2):box%hi(2), box%hlo(1):box%hhi(1)))

--- a/unit-tests/3d/test_mpi_reverse_y.f90
+++ b/unit-tests/3d/test_mpi_reverse_y.f90
@@ -31,9 +31,9 @@ program test_mpi_reverse_y
     lower = (/zero, zero, zero/)
     extent = (/one, one, one/)
 
-    call update_parameters
-
     call mpi_layout_init(lower, extent, nx, ny, nz)
+
+    call update_parameters
 
     allocate(fp(box%lo(3):box%hi(3), box%lo(2):box%hi(2), box%lo(1):box%hi(1)))
     allocate(gp(box%lo(3):box%hi(3), box%lo(2):box%hi(2), box%hlo(1):box%hhi(1)))

--- a/unit-tests/3d/test_mpi_trilinear.f90
+++ b/unit-tests/3d/test_mpi_trilinear.f90
@@ -34,6 +34,8 @@ program test_mpi_trilinear
 
     call register_timer('par2grid', par2grid_timer)
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
     call field_alloc

--- a/unit-tests/3d/test_mpi_vel2vgrad.f90
+++ b/unit-tests/3d/test_mpi_vel2vgrad.f90
@@ -64,6 +64,8 @@ program test_mpi_vel2vgrad
     CC =  one
     c  = -one
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
     call field_default

--- a/unit-tests/3d/test_mpi_vor2vel.f90
+++ b/unit-tests/3d/test_mpi_vor2vel.f90
@@ -49,6 +49,8 @@ program test_mpi_vor2vel
     b = one
     c = one
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
     call field_default

--- a/unit-tests/3d/test_mpi_vtend.f90
+++ b/unit-tests/3d/test_mpi_vtend.f90
@@ -47,6 +47,8 @@ program test_mpi_vtend
     lower  = -f12 * pi * (/one, one, one/)
     extent =  pi * (/one, one, one/)
 
+    call mpi_layout_init(lower, extent, nx, ny, nz)
+
     call update_parameters
 
     call field_default


### PR DESCRIPTION
There is a GCC issue that changes the bounds of allocatable arrays when calling subroutines with `dimension(..)`. See also https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97046 (and https://stackoverflow.com/questions/63824065/lbound-of-an-array-changes-after-call-to-mpi-gatherv-when-using-mpi-f08-module).

As the latest MPI module `mpi_f08` heavily uses `dimension(..)` in its routines, we get wrong bounds after MPI calls, although they are correct before. According to the link I posted, the issue affects `gcc/9.2.0` and `gcc/10.2.0`. It worked on my laptop as I am using `gcc/9.3.0`. One workaround is to specify the bounds explicitly in the MPI calls.

This PR further changes `MPI_INT` to `MPI_INTEGER` and removes the calls to `MPI_Win_sync` as we get the error `Wrong synchronization of RMA calls` on Archer2. These calls are intended to synchronise the private and public RMA memory. However, in a unified memory model, these are not necessary. We have put them in for safety reasons only.

Plus changes in #459 and #460.