### PR TITLE
Fix write_netcdf_axis_3d

### DIFF
--- a/src/netcdf/netcdf_writer.f90
+++ b/src/netcdf/netcdf_writer.f90
@@ -409,12 +409,25 @@ module netcdf_writer
                 z_axis(i) = origin(3) + dble(i) * dx(3)
             enddo
 
-            call write_netcdf_dataset(ncid, dimids(1), x_axis, &
-                                      start=(/start(1)/), cnt=(/cnt(1)/))
-            call write_netcdf_dataset(ncid, dimids(2), y_axis, &
-                                      start=(/start(2)/), cnt=(/cnt(2)/))
-            call write_netcdf_dataset(ncid, dimids(3), z_axis, &
-                                      start=(/start(3)/), cnt=(/cnt(3)/))
+            if (present(start) .and. present(cnt)) then
+                call write_netcdf_dataset(ncid, dimids(1), x_axis, &
+                                          start=(/start(1)/), cnt=(/cnt(1)/))
+                call write_netcdf_dataset(ncid, dimids(2), y_axis, &
+                                          start=(/start(2)/), cnt=(/cnt(2)/))
+                call write_netcdf_dataset(ncid, dimids(3), z_axis, &
+                                          start=(/start(3)/), cnt=(/cnt(3)/))
+            else if (present(start)) then
+                call write_netcdf_dataset(ncid, dimids(1), x_axis, &
+                                          start=(/start(1)/))
+                call write_netcdf_dataset(ncid, dimids(2), y_axis, &
+                                          start=(/start(2)/))
+                call write_netcdf_dataset(ncid, dimids(3), z_axis, &
+                                          start=(/start(3)/))
+            else
+                call write_netcdf_dataset(ncid, dimids(1), x_axis)
+                call write_netcdf_dataset(ncid, dimids(2), y_axis)
+                call write_netcdf_dataset(ncid, dimids(3), z_axis)
+            endif
 
         end subroutine write_netcdf_axis_3d
 


### PR DESCRIPTION
The signature of `write_netcdf_axis_3d` takes two optional parameters. If they are not specified, we get a segmentation fault.

>Program received signal SIGSEGV: Segmentation fault - invalid memory reference.
>Backtrace for this error:
>0  0x7f862565ad21 in ???
>1  0x7f8625659ef5 in ???
>2  0x7f86252b208f in ???
>	at /build/glibc-SzIz7B/glibc-2.31/signal/../sysdeps/unix/sysv/linux/x86_64/sigaction.c:0
>3  0x7f8625b9f448 in __netcdf_writer_MOD_write_netcdf_axis_3d
>	at ../../../src/netcdf/netcdf_writer.f90:413
>4  0x411ab8 in generate_fields
>	at ../../../models/3d/epic3d-models.f90:91
>5  0x40f36b in epic3d_models
>	at ../../../models/3d/epic3d-models.f90:39
>6  0x411bca in main
>	at ../../../models/3d/epic3d-models.f90:5
>Segmentation fault (core dumped)
