### PR TITLE
Fix MPI unit tests

### DIFF
--- a/src/3d/inversion/inversion_utils.f90
+++ b/src/3d/inversion/inversion_utils.f90
@@ -315,6 +315,11 @@ module inversion_utils
             kl = dsqrt(k2l2(ky, kx))
             fac = kl * extent(3)
             ef = dexp(- fac)
+#ifndef NDEBUG
+            ! To avoid "Floating-point exception - erroneous arithmetic operation"
+            ! when ef is really small.
+            ef = max(ef, dsqrt(tiny(ef)))
+#endif
             div = one / (one - ef**2)
             k2ifac = f12 * k2l2i(ky, kx)
 
@@ -323,6 +328,13 @@ module inversion_utils
 
             ep = dexp(- Lp)
             em = dexp(- Lm)
+
+#ifndef NDEBUG
+            ! To avoid "Floating-point exception - erroneous arithmetic operation"
+            ! when ep and em are really small.
+            ep = max(ep, dsqrt(tiny(ep)))
+            em = max(em, dsqrt(tiny(em)))
+#endif
 
             phim(:, ky, kx) = div * (ep - ef * em)
             phip(:, ky, kx) = div * (em - ef * ep)

--- a/unit-tests/3d/test_mpi_gradient_correction_3d.f90
+++ b/unit-tests/3d/test_mpi_gradient_correction_3d.f90
@@ -10,7 +10,7 @@ program test_mpi_gradient_correction_3d
     use mpi_communicator
     use options, only : parcel
     use constants, only : pi, one, zero, f14, f23, f32, two, four, f12, f18
-    use parcel_container, only : n_parcels, parcels, parcel_alloc
+    use parcel_container, only : n_parcels, parcels, n_total_parcels, parcel_alloc
     use parcel_correction, only : apply_gradient            &
                                 , grad_corr_timer           &
                                 , vort_corr_timer           &
@@ -23,6 +23,7 @@ program test_mpi_gradient_correction_3d
     use field_ops
     use parcel_bc
     use parcel_mpi
+    use mpi_collectives, only : mpi_blocking_reduce
     use mpi_timer
     implicit none
 
@@ -65,6 +66,9 @@ program test_mpi_gradient_correction_3d
 
     n_parcels = 8*nz*(hi(1) - lo(1) + 1) * (hi(2) - lo(2) + 1)
     call parcel_alloc(n_parcels)
+
+    n_total_parcels = n_parcels
+    call mpi_blocking_reduce(n_total_parcels, MPI_SUM)
 
     parcel%n_per_cell = 8
     call init_regular_positions

--- a/unit-tests/3d/test_mpi_laplace_correction_3d.f90
+++ b/unit-tests/3d/test_mpi_laplace_correction_3d.f90
@@ -67,7 +67,7 @@ program test_mpi_laplace_correction_3d
     n_parcels = 8*box%ncell
     call parcel_alloc(n_parcels + 1000)
 
-     n_total_parcels = n_parcels
+    n_total_parcels = n_parcels
     call mpi_blocking_reduce(n_total_parcels, MPI_SUM)
 
     parcel%n_per_cell = 8

--- a/unit-tests/3d/test_mpi_nearest_1.f90
+++ b/unit-tests/3d/test_mpi_nearest_1.f90
@@ -41,6 +41,8 @@ program test_mpi_nearest_1
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     call parcel_setup
@@ -79,6 +81,8 @@ program test_mpi_nearest_1
 
         call print_result_logical('Test MPI nearest algorithm: a = b', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_10.f90
+++ b/unit-tests/3d/test_mpi_nearest_10.f90
@@ -42,6 +42,8 @@ program test_mpi_nearest_10
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     call parcel_setup
@@ -80,6 +82,8 @@ program test_mpi_nearest_10
 
         call print_result_logical('Test MPI nearest algorithm: (6) a = b - c', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_11.f90
+++ b/unit-tests/3d/test_mpi_nearest_11.f90
@@ -42,6 +42,8 @@ program test_mpi_nearest_11
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     call parcel_setup
@@ -80,6 +82,8 @@ program test_mpi_nearest_11
 
         call print_result_logical('Test MPI nearest algorithm: (7) a = b - c', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_12.f90
+++ b/unit-tests/3d/test_mpi_nearest_12.f90
@@ -43,6 +43,8 @@ program test_mpi_nearest_12
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     !
@@ -122,6 +124,8 @@ program test_mpi_nearest_12
     if (comm%rank == comm%master) then
         call print_result_logical('Test MPI nearest algorithm: (6) a - b - C', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_13.f90
+++ b/unit-tests/3d/test_mpi_nearest_13.f90
@@ -43,6 +43,8 @@ program test_mpi_nearest_13
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     !
@@ -148,6 +150,8 @@ program test_mpi_nearest_13
     if (comm%rank == comm%master) then
         call print_result_logical('Test MPI nearest algorithm: (8) a = b  C', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_14.f90
+++ b/unit-tests/3d/test_mpi_nearest_14.f90
@@ -43,6 +43,8 @@ program test_mpi_nearest_14
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     !
@@ -122,6 +124,8 @@ program test_mpi_nearest_14
     if (comm%rank == comm%master) then
         call print_result_logical('Test MPI nearest algorithm: (6) a - B - c', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_15.f90
+++ b/unit-tests/3d/test_mpi_nearest_15.f90
@@ -43,6 +43,8 @@ program test_mpi_nearest_15
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     !
@@ -109,6 +111,8 @@ program test_mpi_nearest_15
     if (comm%rank == comm%master) then
         call print_result_logical('Test MPI nearest algorithm: (5) a - b = c - d', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_16.f90
+++ b/unit-tests/3d/test_mpi_nearest_16.f90
@@ -43,6 +43,8 @@ program test_mpi_nearest_16
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     !
@@ -109,6 +111,8 @@ program test_mpi_nearest_16
     if (comm%rank == comm%master) then
         call print_result_logical('Test MPI nearest algorithm: (5) a - b - c = d', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_17.f90
+++ b/unit-tests/3d/test_mpi_nearest_17.f90
@@ -43,6 +43,8 @@ program test_mpi_nearest_17
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     !
@@ -109,6 +111,8 @@ program test_mpi_nearest_17
     if (comm%rank == comm%master) then
         call print_result_logical('Test MPI nearest algorithm: (5) a - B - c - d', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_18.f90
+++ b/unit-tests/3d/test_mpi_nearest_18.f90
@@ -43,6 +43,8 @@ program test_mpi_nearest_18
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     !
@@ -96,6 +98,8 @@ program test_mpi_nearest_18
     if (comm%rank == comm%master) then
         call print_result_logical('Test MPI nearest algorithm: (4) a = b  c = d', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_19.f90
+++ b/unit-tests/3d/test_mpi_nearest_19.f90
@@ -43,6 +43,8 @@ program test_mpi_nearest_19
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     !
@@ -109,6 +111,8 @@ program test_mpi_nearest_19
     if (comm%rank == comm%master) then
         call print_result_logical('Test MPI nearest algorithm: (5) a - b - c - D', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_2.f90
+++ b/unit-tests/3d/test_mpi_nearest_2.f90
@@ -41,6 +41,8 @@ program test_mpi_nearest_2
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     call parcel_setup
@@ -79,6 +81,8 @@ program test_mpi_nearest_2
 
         call print_result_logical('Test MPI nearest algorithm: (2) a = b', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_20.f90
+++ b/unit-tests/3d/test_mpi_nearest_20.f90
@@ -89,6 +89,8 @@ program test_mpi_nearest_20
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     !
@@ -130,6 +132,8 @@ program test_mpi_nearest_20
     if (comm%rank == comm%master) then
         call print_result_logical('Test MPI nearest algorithm: (a, b) - C - (d, e)', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_3.f90
+++ b/unit-tests/3d/test_mpi_nearest_3.f90
@@ -100,7 +100,9 @@ program test_mpi_nearest_3
             iz = k
 
             x = lower(1) + (0.5d0 + dble(ix)) * dx(1)
-            y = lower(2) + (0.5d0 + dble(iy)) * dx(2)
+            ! misalign with centre to avoid round-off errors in
+            ! grid point assignment
+            y = lower(2) + (0.500001d0 + dble(iy)) * dx(2)
             z = lower(3) + (0.5d0 + dble(iz)) * dx(3)
 
             ! big parcel

--- a/unit-tests/3d/test_mpi_nearest_3.f90
+++ b/unit-tests/3d/test_mpi_nearest_3.f90
@@ -41,6 +41,8 @@ program test_mpi_nearest_3
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     call parcel_setup
@@ -79,6 +81,8 @@ program test_mpi_nearest_3
 
         call print_result_logical('Test MPI nearest algorithm: a - B', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_4.f90
+++ b/unit-tests/3d/test_mpi_nearest_4.f90
@@ -99,7 +99,7 @@ program test_mpi_nearest_4
             iy = j
             iz = k
 
-            ! mis-align with centre to avoid round-off errors in
+            ! misalign with centre to avoid round-off errors in
             ! grid point assignment
             x = lower(1) + (0.500001d0 + dble(ix)) * dx(1)
             y = lower(2) + (0.5d0 + dble(iy)) * dx(2)

--- a/unit-tests/3d/test_mpi_nearest_4.f90
+++ b/unit-tests/3d/test_mpi_nearest_4.f90
@@ -41,6 +41,8 @@ program test_mpi_nearest_4
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     call parcel_setup
@@ -79,6 +81,8 @@ program test_mpi_nearest_4
 
         call print_result_logical('Test MPI nearest algorithm: (2) a - B', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_4.f90
+++ b/unit-tests/3d/test_mpi_nearest_4.f90
@@ -99,7 +99,9 @@ program test_mpi_nearest_4
             iy = j
             iz = k
 
-            x = lower(1) + (0.5d0 + dble(ix)) * dx(1)
+            ! mis-align with centre to avoid round-off errors in
+            ! grid point assignment
+            x = lower(1) + (0.500001d0 + dble(ix)) * dx(1)
             y = lower(2) + (0.5d0 + dble(iy)) * dx(2)
             z = lower(3) + (0.5d0 + dble(iz)) * dx(3)
 

--- a/unit-tests/3d/test_mpi_nearest_5.f90
+++ b/unit-tests/3d/test_mpi_nearest_5.f90
@@ -42,6 +42,8 @@ program test_mpi_nearest_5
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     call parcel_setup
@@ -80,6 +82,8 @@ program test_mpi_nearest_5
 
         call print_result_logical('Test MPI nearest algorithm: a = b - c', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_6.f90
+++ b/unit-tests/3d/test_mpi_nearest_6.f90
@@ -42,6 +42,8 @@ program test_mpi_nearest_6
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     call parcel_setup
@@ -80,6 +82,8 @@ program test_mpi_nearest_6
 
         call print_result_logical('Test MPI nearest algorithm: (2) a = b - c', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_7.f90
+++ b/unit-tests/3d/test_mpi_nearest_7.f90
@@ -42,6 +42,8 @@ program test_mpi_nearest_7
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     call parcel_setup
@@ -80,6 +82,8 @@ program test_mpi_nearest_7
 
         call print_result_logical('Test MPI nearest algorithm: (3) a = b - c', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_8.f90
+++ b/unit-tests/3d/test_mpi_nearest_8.f90
@@ -42,6 +42,8 @@ program test_mpi_nearest_8
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     call parcel_setup
@@ -80,6 +82,8 @@ program test_mpi_nearest_8
 
         call print_result_logical('Test MPI nearest algorithm: (4) a = b - c', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_nearest_9.f90
+++ b/unit-tests/3d/test_mpi_nearest_9.f90
@@ -42,6 +42,8 @@ program test_mpi_nearest_9
 
     call update_parameters
 
+    call nearest_win_allocate
+
     call parcel_alloc(max_num_parcels)
 
     call parcel_setup
@@ -80,6 +82,8 @@ program test_mpi_nearest_9
 
         call print_result_logical('Test MPI nearest algorithm: (5) a = b - c', passed)
     endif
+
+    call nearest_win_deallocate
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_reverse_x.f90
+++ b/unit-tests/3d/test_mpi_reverse_x.f90
@@ -11,7 +11,9 @@ program test_mpi_reverse_x
     use stafft
     use mpi_communicator
     use mpi_layout
-    use mpi_reverse, only : reverse_x
+    use mpi_reverse, only : reverse_x               &
+                          , intialise_mpi_reverse   &
+                          , finalise_mpi_reverse
     implicit none
 
     double precision, allocatable :: fp(:, :, :), &
@@ -34,6 +36,8 @@ program test_mpi_reverse_x
     call mpi_layout_init(lower, extent, nx, ny, nz)
 
     call update_parameters
+
+    call intialise_mpi_reverse
 
     allocate(fp(box%lo(3):box%hi(3), box%lo(2):box%hi(2), box%lo(1):box%hi(1)))
     allocate(gp(box%lo(3):box%hi(3), box%lo(2):box%hi(2), box%hlo(1):box%hhi(1)))
@@ -73,6 +77,8 @@ program test_mpi_reverse_x
     else
         call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LAND, comm%master, comm%world, comm%err)
     endif
+
+    call finalise_mpi_reverse
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_reverse_y.f90
+++ b/unit-tests/3d/test_mpi_reverse_y.f90
@@ -11,7 +11,9 @@ program test_mpi_reverse_y
     use stafft
     use mpi_communicator
     use mpi_layout
-    use mpi_reverse, only : reverse_y
+    use mpi_reverse, only : reverse_y               &
+                          , intialise_mpi_reverse   &
+                          , finalise_mpi_reverse
     implicit none
 
     double precision, allocatable :: fp(:, :, :), &
@@ -34,6 +36,8 @@ program test_mpi_reverse_y
     call mpi_layout_init(lower, extent, nx, ny, nz)
 
     call update_parameters
+
+    call intialise_mpi_reverse
 
     allocate(fp(box%lo(3):box%hi(3), box%lo(2):box%hi(2), box%lo(1):box%hi(1)))
     allocate(gp(box%lo(3):box%hi(3), box%lo(2):box%hi(2), box%hlo(1):box%hhi(1)))
@@ -73,6 +77,8 @@ program test_mpi_reverse_y
     else
         call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LAND, comm%master, comm%world, comm%err)
     endif
+
+    call finalise_mpi_reverse
 
     call mpi_comm_finalise
 

--- a/unit-tests/3d/test_mpi_vel2vgrad.f90
+++ b/unit-tests/3d/test_mpi_vel2vgrad.f90
@@ -33,9 +33,9 @@ program test_mpi_vel2vgrad
     use constants, only : zero, one, two, four, pi, twopi
     use parameters, only : lower, update_parameters, dx, nx, ny, nz, extent
     use fields, only : vortg, velog, velgradg, field_default
-    use inversion_utils, only : init_inversion
+    use inversion_utils, only : init_inversion, finalise_inversion
     use inversion_mod, only : vel2vgrad
-    use sta3dfft, only : fftxyp2s, finalise_fft
+    use sta3dfft, only : fftxyp2s
     use mpi_timer
     use mpi_communicator
     use mpi_layout
@@ -108,7 +108,7 @@ program test_mpi_vel2vgrad
 
     call vel2vgrad(svelog)
 
-    call finalise_fft
+    call finalise_inversion
 
     error = maxval(dabs(velgradg(0:nz, box%lo(2):box%hi(2), box%lo(1):box%hi(1), :)   &
                         - strain(0:nz, box%lo(2):box%hi(2), box%lo(1):box%hi(1), :)))


### PR DESCRIPTION
This PR
* fixes some unit tests after changing the initialisation interface of `mpi_reverse.f90` and `parcel_nearest.f90`.
* fixes the `Floating-point exception - erroneous arithmetic operation` error happening in `set_hyperbolic_functions` of `inversion_utils.f90` due to underflow. This fix is only applied in debug mode.
* slightly misaligns the position of `x` or `y` in `test_mpi_nearest_3.f90` and `test_mpi_nearest_4.f90` as round-off errors cause the parcels to be assigned to different grid points that then results in `Merge error: no near neighbour found`.
* fixes `n_total_parcels` in `test_mpi_gradient_correction_3d.f90`.