### PR TITLE
No allocatable strings

### DIFF
--- a/analyse/2d/genspec2d.f90
+++ b/analyse/2d/genspec2d.f90
@@ -197,9 +197,9 @@ program genspec
         end subroutine read_data
 
         subroutine write_spectrum
-            logical                   :: exists = .false.
-            character(:), allocatable :: fname
-            integer                   :: pos
+            logical        :: exists = .false.
+            character(512) :: fname
+            integer        :: pos
 
             ! 1 October 2021
             ! https://stackoverflow.com/questions/36731707/fortran-how-to-remove-file-extension-from-character

--- a/analyse/3d/genspec3d.f90
+++ b/analyse/3d/genspec3d.f90
@@ -229,9 +229,9 @@ program genspec
         end subroutine read_data
 
         subroutine write_spectrum
-            logical                   :: exists = .false.
-            character(:), allocatable :: fname
-            integer                   :: pos
+            logical        :: exists = .false.
+            character(512) :: fname
+            integer        :: pos
 
             ! 1 October 2021
             ! https://stackoverflow.com/questions/36731707/fortran-how-to-remove-file-extension-from-character

--- a/configure.ac
+++ b/configure.ac
@@ -423,8 +423,8 @@ AM_CONDITIONAL([ENABLE_DEBUG], [test "$ENABLE_DEBUG" = "yes"])
 AC_MSG_CHECKING([whether we are compiling in debug mode])
 if test "x$ENABLE_DEBUG" = "xyes"; then
     AC_MSG_RESULT([yes])
-    FCFLAGS="$FCFLAGS -Wall -Wno-maybe-uninitialized -Werror -g -O0"
-    FCFLAGS="$FCFLAGS -fcheck=all -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow,underflow"
+    FCFLAGS="$FCFLAGS -Wall -Wuninitialized -Wmaybe-uninitialized -Werror -g -O0"
+    FCFLAGS="$FCFLAGS -fcheck=all -fbounds-check -fbacktrace -ffpe-trap=denormal,invalid,zero,overflow,underflow"
 else
     AC_MSG_RESULT([no])
     FCFLAGS="$FCFLAGS -O3 -funroll-all-loops -flto -DNDEBUG"

--- a/src/2d/stepper/rk4_utils.f90
+++ b/src/2d/stepper/rk4_utils.f90
@@ -42,7 +42,7 @@ module rk4_utils
             double precision             :: dbdz(0:nz, 0:nx-1)
 #if ENABLE_VERBOSE
             logical                      :: exists = .false.
-            character(:), allocatable    :: fname
+            character(512)               :: fname
 #endif
 
             ! velocity strain

--- a/src/2d/utils/utils.f90
+++ b/src/2d/utils/utils.f90
@@ -185,12 +185,12 @@ module utils
             call set_netcdf_axes((/'X', 'Z', 'T'/))
 
             if (l_restart) then
-                fname = trim(restart_file)
+                fname = restart_file
             else
-                fname = trim(field_file)
+                fname = field_file
             endif
 
-            call open_netcdf_file(fname, NF90_NOWRITE, ncid)
+            call open_netcdf_file(trim(fname), NF90_NOWRITE, ncid)
 
             call get_netcdf_box(ncid, lower, extent, ncells)
             call read_physical_quantities(ncid)

--- a/src/2d/utils/utils.f90
+++ b/src/2d/utils/utils.f90
@@ -176,9 +176,9 @@ module utils
         end subroutine setup_restart
 
         subroutine setup_domain_and_parameters
-            character(:), allocatable :: fname
-            integer                   :: ncid
-            integer                   :: ncells(2)
+            character(512) :: fname = ''
+            integer        :: ncid
+            integer        :: ncells(2)
 
             ! set axis and dimension names for the NetCDF output
             call set_netcdf_dimensions((/'x', 'z', 't'/))

--- a/src/3d/stepper/rk4_utils.f90
+++ b/src/3d/stepper/rk4_utils.f90
@@ -87,7 +87,7 @@ module rk4_utils
             integer                      :: ix, iy, iz
 #if ENABLE_VERBOSE
             logical                      :: exists = .false.
-            character(:), allocatable    :: fname
+            character(512)               :: fname
 #endif
 
             !
@@ -184,13 +184,13 @@ module rk4_utils
 #ifdef ENABLE_VERBOSE
             if (comm%rank == comm%master) then
                 fname = trim(output%basename) // '_alpha_time_step.asc'
-                inquire(file=fname, exist=exists)
+                inquire(file=trim(fname), exist=exists)
                 ! 23 August
                 ! https://stackoverflow.com/questions/15526203/single-command-to-open-a-file-or-create-it-and-the-append-data
                 if ((t /= zero) .and. exists) then
-                    open(unit=1235, file=fname, status='old', position='append')
+                    open(unit=1235, file=trim(fname), status='old', position='append')
                 else
-                    open(unit=1235, file=fname, status='replace')
+                    open(unit=1235, file=trim(fname), status='replace')
                     write(1235, *) '  # time (s)                \alpha_s/\gamma_{max}     \alpha_b/N_{max}'
                 endif
 

--- a/src/3d/utils/utils.f90
+++ b/src/3d/utils/utils.f90
@@ -146,21 +146,21 @@ module utils
         end subroutine setup_restart
 
         subroutine setup_domain_and_parameters
-            character(:), allocatable :: fname
-            integer                   :: ncid
-            integer                   :: ncells(3)
+            character(512) :: fname
+            integer        :: ncid
+            integer        :: ncells(3)
 
             ! set axis and dimension names for the NetCDF output
             call set_netcdf_dimensions((/'x', 'y', 'z', 't'/))
             call set_netcdf_axes((/'X', 'Y', 'Z', 'T'/))
 
             if (l_restart) then
-                fname = trim(restart_file)
+                fname = restart_file
             else
-                fname = trim(field_file)
+                fname = field_file
             endif
 
-            call open_netcdf_file(fname, NF90_NOWRITE, ncid)
+            call open_netcdf_file(trim(fname), NF90_NOWRITE, ncid)
 
             call get_netcdf_box(ncid, lower, extent, ncells)
             call read_physical_quantities(ncid)


### PR DESCRIPTION
When compiling with `-Wuninitialized -Wmaybe-uninitialized` we get warnings of "maybe uninitialised" variables. The reason are  `allocatable` characters. We get rid of them by specifying a size.