### PR TITLE
Communicate veta and vtau

### DIFF
--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -5,7 +5,11 @@
 module parcel_container
     use options, only : verbose
     use parameters, only : extent, extenti, center, lower, upper
-    use parcel_ellipsoid, only : parcel_ellipsoid_allocate, parcel_ellipsoid_deallocate
+    use parcel_ellipsoid, only : parcel_ellipsoid_allocate    &
+                               , parcel_ellipsoid_deallocate  &
+                               , set_ellipsoid_buffer_indices &
+                               , parcel_ellipsoid_serialize   &
+                               , parcel_ellipsoid_deserialize
     use mpi_communicator
     use mpi_collectives, only : mpi_blocking_reduce
     use mpi_utils, only : mpi_exit_on_error

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -126,7 +126,9 @@ module parcel_container
             IDX_RK4_DWDX = i + 14
             IDX_RK4_DWDY = i + 15
 
-            n_par_attrib = set_ellipsoid_buffer_indices(i, 16)
+            i = i + 16
+
+            n_par_attrib = set_ellipsoid_buffer_indices(i)
 
         end subroutine set_buffer_indices
 

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -126,7 +126,7 @@ module parcel_container
             IDX_RK4_DWDX = i + 14
             IDX_RK4_DWDY = i + 15
 
-            n_par_attrib = IDX_RK4_DWDY
+            n_par_attrib = set_ellipsoid_buffer_indices(i, 16)
 
         end subroutine set_buffer_indices
 
@@ -320,6 +320,8 @@ module parcel_container
             buffer(IDX_RK4_X_DVOR:IDX_RK4_Z_DVOR) = parcels%delta_vor(:, n)
             buffer(IDX_RK4_DB11:IDX_RK4_DB23)     = parcels%delta_b(:, n)
             buffer(IDX_RK4_DUDX:IDX_RK4_DWDY)     = parcels%strain(:, n)
+
+            call parcel_ellipsoid_serialize(n, buffer)
         end subroutine parcel_serialize
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -342,6 +344,8 @@ module parcel_container
             parcels%delta_vor(:, n) = buffer(IDX_RK4_X_DVOR:IDX_RK4_Z_DVOR)
             parcels%delta_b(:, n)   = buffer(IDX_RK4_DB11:IDX_RK4_DB23)
             parcels%strain(:, n)    = buffer(IDX_RK4_DUDX:IDX_RK4_DWDY)
+
+            call parcel_ellipsoid_deserialize(n, buffer)
         end subroutine parcel_deserialize
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -53,8 +53,9 @@ module parcel_ellipsoid
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-        pure function set_ellipsoid_buffer_indices(i) restul(n_attr)
+        function set_ellipsoid_buffer_indices(i) result(n_attr)
             integer, intent(in) :: i
+            integer             :: n_attr
 
             IDX_ELL_VETA = i
             IDX_ELL_VTAU = i + 3
@@ -80,7 +81,7 @@ module parcel_ellipsoid
             double precision, intent(in) :: buffer(:)
 
             Vetas(:, n) = buffer(IDX_ELL_VETA:IDX_ELL_VETA+2)
-            Vtaus(:. n) = buffer(IDX_ELL_VTAU:IDX_ELL_VTAU+2)
+            Vtaus(:, n) = buffer(IDX_ELL_VTAU:IDX_ELL_VTAU+2)
 
         end subroutine parcel_ellipsoid_deserialize
 

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -35,9 +35,38 @@ module parcel_ellipsoid
                         , I_B22 = 4 & ! index for B22 matrix component
                         , I_B23 = 5   ! index for B23 matrix component
 
+    integer :: IDX_ELL_VETA, IDX_ELL_VTAU
+
     private :: rho, f3pi4, f5pi4, f7pi4, costheta, sintheta, get_upper_triangular, Vetas, Vtaus
 
     contains
+
+        pure function set_ellipsoid_buffer_indices(i, j) restul(n_attr)
+            integer, intent(in) :: i, j
+
+            IDX_ELL_VETA = i + j
+            IDX_ELL_VTAU = i + j + 3
+
+            n_attr = IDX_ELL_VTAU + 2
+        end function set_ellispoid_buffer_indices
+
+        subroutine parcel_ellipsoid_serialize(n, buffer)
+            integer,          intent(in)    :: n
+            double precision, intent(inout) :: buffer(:)
+
+            buffer(IDX_ELL_VETA:IDX_ELL_VETA+2) = Vetas(:, n)
+            buffer(IDX_ELL_VTAU:IDX_ELL_VTAU+2) = Vtaus(:, n)
+
+        end subroutine parcel_ellipsoid_serialize
+
+        subroutine parcel_ellipsoid_deserialize(n, buffer)
+            integer,          intent(in) :: n
+            double precision, intent(in) :: buffer(:)
+
+            Vetas(:, n) = buffer(IDX_ELL_VETA:IDX_ELL_VETA+2)
+            Vtaus(:. n) = buffer(IDX_ELL_VTAU:IDX_ELL_VTAU+2)
+
+        end subroutine parcel_ellipsoid_deserialize
 
         subroutine parcel_ellipsoid_allocate(num)
             integer, intent(in) :: num

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -37,18 +37,32 @@ module parcel_ellipsoid
 
     integer :: IDX_ELL_VETA, IDX_ELL_VTAU
 
-    private :: rho, f3pi4, f5pi4, f7pi4, costheta, sintheta, get_upper_triangular, Vetas, Vtaus
+    private :: rho                  &
+             , f3pi4                &
+             , f5pi4                &
+             , f7pi4                &
+             , costheta             &
+             , sintheta             &
+             , get_upper_triangular &
+             , Vetas                &
+             , Vtaus                &
+             , IDX_ELL_VETA         &
+             , IDX_ELL_VTAU
 
     contains
 
-        pure function set_ellipsoid_buffer_indices(i, j) restul(n_attr)
-            integer, intent(in) :: i, j
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-            IDX_ELL_VETA = i + j
-            IDX_ELL_VTAU = i + j + 3
+        pure function set_ellipsoid_buffer_indices(i) restul(n_attr)
+            integer, intent(in) :: i
+
+            IDX_ELL_VETA = i
+            IDX_ELL_VTAU = i + 3
 
             n_attr = IDX_ELL_VTAU + 2
-        end function set_ellispoid_buffer_indices
+        end function set_ellipsoid_buffer_indices
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         subroutine parcel_ellipsoid_serialize(n, buffer)
             integer,          intent(in)    :: n
@@ -59,6 +73,8 @@ module parcel_ellipsoid
 
         end subroutine parcel_ellipsoid_serialize
 
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
         subroutine parcel_ellipsoid_deserialize(n, buffer)
             integer,          intent(in) :: n
             double precision, intent(in) :: buffer(:)
@@ -68,12 +84,16 @@ module parcel_ellipsoid
 
         end subroutine parcel_ellipsoid_deserialize
 
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
         subroutine parcel_ellipsoid_allocate(num)
             integer, intent(in) :: num
 
             allocate(Vetas(3, num))
             allocate(Vtaus(3, num))
         end subroutine parcel_ellipsoid_allocate
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         subroutine parcel_ellipsoid_deallocate
 
@@ -84,6 +104,8 @@ module parcel_ellipsoid
             deallocate(Vetas)
             deallocate(Vtaus)
         end subroutine parcel_ellipsoid_deallocate
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         ! Obtain the parcel shape matrix.
         ! @param[in] B = (B11, B12, B13, B22, B23)


### PR DESCRIPTION
We must communicate Veta and Vtau as well. Another solution: We do not reuse them, but calculate them all the time in `vol2grid`, `par2grid` and the parcel corrections. We must communicate them due to the parcel halo swap calls.