### PR TITLE
Pull optimizations to serial version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## EPIC version 0.12.6
+* [Pull optimizations to serial version](https://github.com/EPIC-model/epic/pull/500)
+
 ## EPIC version 0.12.5
 * [Update requirements.txt](https://github.com/EPIC-model/epic/pull/450)
 * [Fix the calculation of the vorticity correction](https://github.com/EPIC-model/epic/pull/484)

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([epic], [0.12.5], [mf248@st-andrews.ac.uk], [], [https://github.com/matt-frey/epic])
+AC_INIT([epic], [0.12.6], [mf248@st-andrews.ac.uk], [], [https://github.com/matt-frey/epic])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_PROG_FC([gfortran])
 AC_LANG(Fortran)

--- a/examples/beltrami.config
+++ b/examples/beltrami.config
@@ -2,7 +2,8 @@
 &EPIC
 
  field_file              = 'beltrami_32x32x32.nc'    ! input field file
- field_tol               = 1.0e-12                   ! tolerance for parcel generation
+
+ rk_order                = 4
 
  !
  ! output info

--- a/examples/beltrami.config
+++ b/examples/beltrami.config
@@ -26,7 +26,6 @@
  parcel%n_per_cell       = 8             ! initial number of parcels per cell
  parcel%lambda_max       = 4.0           ! maximum parcel aspect ratio
  parcel%min_vratio       = 40.0          ! minimum ratio of grid cell volume / parcel volume
- parcel%max_vratio       = 4.913         ! maximum ratio of grid cell volume / parcel volume
  parcel%correction_iters = 2             ! how many parcel correction iterations
  parcel%gradient_pref    = 1.8           ! gradient correction prefactor
  parcel%max_compression  = 0.5           ! gradient correction maximum compression

--- a/examples/moist.config
+++ b/examples/moist.config
@@ -4,6 +4,8 @@
  field_file              = 'moist.nc'       ! input field file
  field_tol               = 1.0e-9           ! tolerance for parcel generation
 
+ rk_order                = 4
+
  !
  ! output info
  !

--- a/examples/moist.config
+++ b/examples/moist.config
@@ -26,7 +26,6 @@
  parcel%n_per_cell       = 8                ! initial number of parcels per cell
  parcel%lambda_max       = 4.0              ! maximum parcel aspect ratio
  parcel%min_vratio       = 40.0             ! minimum ratio of grid cell volume / parcel volume
- parcel%max_vratio       = 4.913            ! maximum ratio of grid cell volume / parcel volume
  parcel%correction_iters = 2                ! how many parcel correction iterations
  parcel%gradient_pref    = 1.8              ! gradient correction prefactor
  parcel%max_compression  = 0.5              ! gradient correction maximum compression

--- a/examples/robert3d.config
+++ b/examples/robert3d.config
@@ -26,7 +26,6 @@
  parcel%n_per_cell       = 8                 ! initial number of parcels per cell
  parcel%lambda_max       = 4.0               ! maximum parcel aspect ratio
  parcel%min_vratio       = 40.0              ! minimum ratio of grid cell volume / parcel volume
- parcel%max_vratio       = 4.913             ! maximum ratio of grid cell volume / parcel volume
  parcel%correction_iters = 2                 ! how many parcel correction iterations
  parcel%gradient_pref    = 1.8               ! gradient correction prefactor
  parcel%max_compression  = 0.5               ! gradient correction maximum compression

--- a/examples/robert3d.config
+++ b/examples/robert3d.config
@@ -4,6 +4,8 @@
  field_file              = 'robert3d.nc'    ! input field file
  field_tol               = 1.0e-9           ! tolerance for parcel generation
 
+ rk_order                = 4
+
  !
  ! output info
  !

--- a/python-scripts/tools/animate/bokeh_animation.py
+++ b/python-scripts/tools/animate/bokeh_animation.py
@@ -48,12 +48,6 @@ class BokehAnimation:
             if coloring == "aspect-ratio":
                 vmin = 1.0
                 vmax = self.ncreader.get_global_attribute("lambda_max")
-            elif coloring == "vol-distr":
-                extent = self.ncreader.get_box_extent()
-                ncells = self.ncreader.get_box_ncells()
-                vcell = np.prod(extent / ncells)
-                vmin = vcell / self.ncreader.get_global_attribute("min_vratio")
-                vmax = vcell / self.ncreader.get_global_attribute("max_vratio")
             else:
                 vmin, vmax = self.ncreader.get_dataset_min_max(coloring)
 

--- a/python-scripts/tools/bokeh_plots.py
+++ b/python-scripts/tools/bokeh_plots.py
@@ -286,11 +286,6 @@ def _bokeh_plot_parcels(ncreader, step, coloring, vmin, vmax, **kwargs):
     if coloring == "aspect-ratio":
         label = "aspect ratio"
         data = ncreader.get_aspect_ratio(step=step)
-    elif coloring == "vol-distr":
-        label = "volume distribution"
-        data = ncreader.get_dataset(step=step, name="volume")
-        data[data <= vmin] = 0.0
-        data[data > vmin] = 1.0
     else:
         label = coloring
         data = ncreader.get_dataset(step=step, name=coloring)
@@ -332,35 +327,16 @@ def _bokeh_plot_parcels(ncreader, step, coloring, vmin, vmax, **kwargs):
 
     mapper = None
     color_bar = None
-    if coloring == "vol-distr":
-        mapper = linear_cmap(
-            field_name="fill_color", palette=["blue", "red"], low=0, high=1
-        )
-        # 5 August 2021
-        # https://stackoverflow.com/questions/63344015/how-do-i-get-a-bokeh-colorbar-to-show-the-min-and-max-value
-        ticker = FixedTicker(ticks=[0, 0.5, 1])
-        color_bar = ColorBar(
-            color_mapper=mapper["transform"],
-            label_standoff=12,
-            ticker=ticker,
-            title_text_font_size=font_size,
-            major_label_text_font=text_font,
-            major_label_text_font_size=font_size,
-        )
-        # 5 August 2021
-        # https://stackoverflow.com/questions/37173230/how-do-i-use-custom-labels-for-ticks-in-bokeh
-        color_bar.major_label_overrides = {0: "0", 0.5: "Vmin", 1: "Vmax"}
-    else:
-        mapper = linear_cmap(
-            field_name="fill_color", palette=palette, low=vmin, high=vmax
-        )
-        color_bar = ColorBar(
-            color_mapper=mapper["transform"],
-            label_standoff=12,
-            title_text_font_size=font_size,
-            major_label_text_font=text_font,
-            major_label_text_font_size=font_size,
-        )
+    mapper = linear_cmap(
+        field_name="fill_color", palette=palette, low=vmin, high=vmax
+    )
+    color_bar = ColorBar(
+        color_mapper=mapper["transform"],
+        label_standoff=12,
+        title_text_font_size=font_size,
+        major_label_text_font=text_font,
+        major_label_text_font_size=font_size,
+    )
 
     graph.ellipse(
         x="x",
@@ -411,12 +387,6 @@ def bokeh_plot(fname, step, show=False, fmt="png", coloring="vorticity", **kwarg
         if coloring == "aspect-ratio":
             vmin = 1.0
             vmax = ncreader.get_global_attribute("lambda_max")
-        elif coloring == "vol-distr":
-            extent = ncreader.get_box_extent()
-            ncells = ncreader.get_box_ncells()
-            vcell = np.prod(extent / ncells)
-            vmin = vcell / ncreader.get_global_attribute("min_vratio")
-            vmax = vcell / ncreader.get_global_attribute("max_vratio")
         else:
             vmin, vmax = ncreader.get_dataset_min_max(coloring)
 

--- a/src/3d/Makefile.am
+++ b/src/3d/Makefile.am
@@ -29,8 +29,8 @@ epic3d_SOURCES = 				\
 	parcels/parcel_netcdf.f90		\
 	parcels/parcel_diagnostics_netcdf.f90	\
 	utils/utils.f90				\
-	stepper/rk4_utils.f90			\
-	stepper/ls_rk4.f90			\
+	stepper/rk_utils.f90			\
+	stepper/ls_rk.f90			\
 	epic3d.f90
 
 epic3d_LDADD = 						\

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -31,7 +31,6 @@ program epic3d
     use utils, only : write_last_step, setup_output_files        &
                     , setup_restart, setup_domain_and_parameters &
                     , setup_fields_and_parcels
-    use parameters, only : max_num_parcels
     use options, only : rk_order
     implicit none
 

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -121,7 +121,7 @@ program epic3d
 
                 call merge_parcels(parcels)
 
-                call parcel_split(parcels, parcel%lambda_max)
+                call parcel_split
 
                 do cor_iter = 1, parcel%correction_iters
                     call apply_laplace((cor_iter > 1))

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -27,7 +27,7 @@ program epic3d
     use inversion_utils, only : init_inversion
     use parcel_interpl, only : grid2par_timer, par2grid_timer
     use parcel_init, only : init_timer
-    use ls_rk, only : ls_rk4_alloc, ls_rk4_dealloc, ls_rk_step, rk_timer, ls_rk_setu
+    use ls_rk, only : ls_rk_step, rk_timer, ls_rk_setup
     use utils, only : write_last_step, setup_output_files        &
                     , setup_restart, setup_domain_and_parameters &
                     , setup_fields_and_parcels
@@ -86,8 +86,6 @@ program epic3d
 
             call setup_fields_and_parcels
 
-            call ls_rk4_alloc(max_num_parcels)
-
             call ls_rk_setup(rk_order)
 
             call init_inversion
@@ -142,7 +140,6 @@ program epic3d
         subroutine post_run
             use options, only : output
             call parcel_dealloc
-            call ls_rk4_dealloc
             call stop_timer(epic_timer)
 
             call write_time_to_csv(output%basename)

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -27,11 +27,12 @@ program epic3d
     use inversion_utils, only : init_inversion
     use parcel_interpl, only : grid2par_timer, par2grid_timer
     use parcel_init, only : init_timer
-    use ls_rk4, only : ls_rk4_alloc, ls_rk4_dealloc, ls_rk4_step, rk4_timer
+    use ls_rk, only : ls_rk4_alloc, ls_rk4_dealloc, ls_rk_step, rk_timer, ls_rk_setu
     use utils, only : write_last_step, setup_output_files        &
                     , setup_restart, setup_domain_and_parameters &
                     , setup_fields_and_parcels
     use parameters, only : max_num_parcels
+    use options, only : rk_order
     implicit none
 
     integer          :: epic_timer
@@ -70,7 +71,7 @@ program epic3d
             call register_timer('field diagnostics I/O', field_stats_io_timer)
             call register_timer('vor2vel', vor2vel_timer)
             call register_timer('vorticity tendency', vtend_timer)
-            call register_timer('parcel push', rk4_timer)
+            call register_timer('parcel push', rk_timer)
             call register_timer('merge nearest', merge_nearest_timer)
             call register_timer('merge tree resolve', merge_tree_resolve_timer)
 
@@ -85,6 +86,8 @@ program epic3d
             call setup_fields_and_parcels
 
             call ls_rk4_alloc(max_num_parcels)
+
+            call ls_rk_setup(rk_order)
 
             call init_inversion
 
@@ -114,7 +117,7 @@ program epic3d
 #endif
                 call apply_vortcor
 
-                call ls_rk4_step(t)
+                call ls_rk_step(t)
 
                 call merge_parcels(parcels)
 

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -55,6 +55,7 @@ program epic3d
             use options, only : read_config_file
 
             call register_timer('epic', epic_timer)
+            call register_timer('parcel container resize', resize_timer)
             call register_timer('par2grid', par2grid_timer)
             call register_timer('grid2par', grid2par_timer)
             call register_timer('parcel split', split_timer)

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -5,7 +5,9 @@
 module parcel_container
     use options, only : verbose
     use parameters, only : extent, extenti, center, lower, upper, set_max_num_parcels
-    use parcel_ellipsoid, only : parcel_ellipsoid_allocate, parcel_ellipsoid_deallocate
+    use parcel_ellipsoid, only : parcel_ellipsoid_allocate      &
+                               , parcel_ellipsoid_deallocate    &
+                               , parcel_ellipsoid_resize
     use armanip, only : resize_array
     implicit none
 

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -9,9 +9,12 @@ module parcel_container
                                , parcel_ellipsoid_deallocate    &
                                , parcel_ellipsoid_resize
     use armanip, only : resize_array
+    use mpi_timer, only : start_timer, stop_timer
     implicit none
 
     integer :: n_parcels
+
+    integer :: resize_timer
 
     type parcel_container_type
         double precision, allocatable, dimension(:, :) :: &
@@ -119,6 +122,8 @@ module parcel_container
         subroutine parcel_resize(new_size)
             integer, intent(in) :: new_size
 
+            call start_timer(resize_timer)
+
             if (new_size < n_parcels) then
                 print *, "Losing parcels when resizing."
                 stop
@@ -142,6 +147,8 @@ module parcel_container
             call resize_array(parcels%delta_vor, new_size)
             call resize_array(parcels%strain, new_size)
             call resize_array(parcels%delta_b, new_size)
+
+            call stop_timer(resize_timer)
 
         end subroutine parcel_resize
 

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -117,6 +117,11 @@ module parcel_container
         subroutine parcel_resize(new_size)
             integer, intent(in) :: new_size
 
+            if (new_size < n_parcels) then
+                call mpi_exit_on_error(&
+                    "in parcel_container::parcel_resize: losing parcels when resizing.")
+            endif
+
             call set_max_num_parcels(new_size)
 
             call resize_array(parcels%position, new_size)

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -118,8 +118,8 @@ module parcel_container
             integer, intent(in) :: new_size
 
             if (new_size < n_parcels) then
-                call mpi_exit_on_error(&
-                    "in parcel_container::parcel_resize: losing parcels when resizing.")
+                print *, "Losing parcels when resizing."
+                stop
             endif
 
             call set_max_num_parcels(new_size)

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -4,7 +4,7 @@
 ! =============================================================================
 module parcel_container
     use options, only : verbose
-    use parameters, only : extent, extenti, center, lower, upper
+    use parameters, only : extent, extenti, center, lower, upper, set_max_num_parcels
     use parcel_ellipsoid, only : parcel_ellipsoid_allocate, parcel_ellipsoid_deallocate
     use armanip, only : resize_array
     implicit none
@@ -116,6 +116,8 @@ module parcel_container
         ! @param[in] new_size is the new size of each attribute
         subroutine parcel_resize(new_size)
             integer, intent(in) :: new_size
+
+            call set_max_num_parcels(new_size)
 
             call resize_array(parcels%position, new_size)
 

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -6,6 +6,7 @@ module parcel_container
     use options, only : verbose
     use parameters, only : extent, extenti, center, lower, upper
     use parcel_ellipsoid, only : parcel_ellipsoid_allocate, parcel_ellipsoid_deallocate
+    use armanip, only : resize_array
     implicit none
 
     integer :: n_parcels
@@ -108,6 +109,34 @@ module parcel_container
             parcels%B(:, n) = parcels%B(:, m)
 
         end subroutine parcel_replace
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        ! Resize the parcel container
+        ! @param[in] new_size is the new size of each attribute
+        subroutine parcel_resize(new_size)
+            integer, intent(in) :: new_size
+
+            call resize_array(parcels%position, new_size)
+
+            call resize_array(parcels%vorticity, new_size)
+            call resize_array(parcels%B, new_size)
+            call resize_array(parcels%volume, new_size)
+            call resize_array(parcels%buoyancy, new_size)
+#ifndef ENABLE_DRY_MODE
+            call resize_array(parcels%humidity, new_size)
+#endif
+            call parcel_ellipsoid_resize(new_size)
+
+            ! LS-RK4 variables
+            call resize_array(parcels%delta_pos, new_size)
+            call resize_array(parcels%delta_vor, new_size)
+            call resize_array(parcels%strain, new_size)
+            call resize_array(parcels%delta_b, new_size)
+
+        end subroutine parcel_resize
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         ! Allocate parcel memory
         ! @param[in] num number of parcels

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -131,22 +131,22 @@ module parcel_container
 
             call set_max_num_parcels(new_size)
 
-            call resize_array(parcels%position, new_size)
+            call resize_array(parcels%position, new_size, n_parcels)
 
-            call resize_array(parcels%vorticity, new_size)
-            call resize_array(parcels%B, new_size)
-            call resize_array(parcels%volume, new_size)
-            call resize_array(parcels%buoyancy, new_size)
+            call resize_array(parcels%vorticity, new_size, n_parcels)
+            call resize_array(parcels%B, new_size, n_parcels)
+            call resize_array(parcels%volume, new_size, n_parcels)
+            call resize_array(parcels%buoyancy, new_size, n_parcels)
 #ifndef ENABLE_DRY_MODE
-            call resize_array(parcels%humidity, new_size)
+            call resize_array(parcels%humidity, new_size, n_parcels)
 #endif
-            call parcel_ellipsoid_resize(new_size)
+            call parcel_ellipsoid_resize(new_size, n_parcels)
 
             ! LS-RK4 variables
-            call resize_array(parcels%delta_pos, new_size)
-            call resize_array(parcels%delta_vor, new_size)
-            call resize_array(parcels%strain, new_size)
-            call resize_array(parcels%delta_b, new_size)
+            call resize_array(parcels%delta_pos, new_size, n_parcels)
+            call resize_array(parcels%delta_vor, new_size, n_parcels)
+            call resize_array(parcels%strain, new_size, n_parcels)
+            call resize_array(parcels%delta_b, new_size, n_parcels)
 
             call stop_timer(resize_timer)
 

--- a/src/3d/parcels/parcel_diagnostics.f90
+++ b/src/3d/parcels/parcel_diagnostics.f90
@@ -82,8 +82,7 @@ module parcel_diagnostics
 
 
         ! Calculate all parcel related diagnostics
-        subroutine calculate_parcel_diagnostics(velocity)
-            double precision, intent(in) :: velocity(:, :)
+        subroutine calculate_parcel_diagnostics
             integer          :: n
             double precision :: b, z, vel(3), vol, zmin, vor(3), pe
             double precision :: evals(3), lam, lsum, l2sum, v2sum
@@ -120,7 +119,7 @@ module parcel_diagnostics
             !$omp& reduction(-: pe) reduction(max: bmax) reduction(min: bmin)
             do n = 1, n_parcels
 
-                vel = velocity(:, n)
+                vel = parcels%delta_pos(:, n)
                 vor = parcels%vorticity(:, n)
                 vol = parcels%volume(n)
                 b   = parcels%buoyancy(n)

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -17,7 +17,8 @@ module parcel_ellipsoid
                         , five  &
                         , seven
     use parameters, only : max_num_parcels
-    use jacobi
+    use scherzinger, only : scherzinger_diagonalise &
+                          , scherzinger_eigenvalues
     implicit none
 
     double precision, parameter :: rho = dsqrt(two / five)
@@ -78,7 +79,7 @@ module parcel_ellipsoid
 
             U = get_upper_triangular(B, volume)
 
-            call jacobi_eigenvalues(U, D)
+            call scherzinger_eigenvalues(U, D)
 
 #ifndef NDEBUG
             ! check if any eigenvalue is less or equal zero
@@ -114,7 +115,7 @@ module parcel_ellipsoid
 
             U = get_upper_triangular(B, volume)
 
-            call jacobi_diagonalise(U, D, V)
+            call scherzinger_diagonalise(U, D, V)
 
 #ifndef NDEBUG
             ! check if any eigenvalue is less or equal zero
@@ -142,7 +143,7 @@ module parcel_ellipsoid
 
             U = get_upper_triangular(B, volume)
 
-            call jacobi_diagonalise(U, D, V)
+            call scherzinger_diagonalise(U, D, V)
 
 #ifndef NDEBUG
             ! check if any eigenvalue is less or equal zero

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -41,11 +41,11 @@ module parcel_ellipsoid
 
     contains
 
-        subroutine parcel_ellipsoid_resize(new_size, copy_size)
-            integer, intent(in) :: new_size, copy_size
+        subroutine parcel_ellipsoid_resize(new_size, old_size)
+            integer, intent(in) :: new_size, old_size
 
-            call resize_array(Vetas, new_size, copy_size)
-            call resize_array(Vtaus, new_size, copy_size)
+            call resize_array(Vetas, new_size, old_size)
+            call resize_array(Vtaus, new_size, old_size)
 
         end subroutine parcel_ellipsoid_resize
 

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -41,11 +41,11 @@ module parcel_ellipsoid
 
     contains
 
-        subroutine parcel_ellipsoid_resize(new_size, old_size)
-            integer, intent(in) :: new_size, old_size
+        subroutine parcel_ellipsoid_resize(new_size, copy_size)
+            integer, intent(in) :: new_size, copy_size
 
-            call resize_array(Vetas, new_size, old_size)
-            call resize_array(Vtaus, new_size, old_size)
+            call resize_array(Vetas, new_size, copy_size)
+            call resize_array(Vtaus, new_size, copy_size)
 
         end subroutine parcel_ellipsoid_resize
 

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -19,6 +19,7 @@ module parcel_ellipsoid
     use parameters, only : max_num_parcels
     use scherzinger, only : scherzinger_diagonalise &
                           , scherzinger_eigenvalues
+    use armanip, only : resize_array
     implicit none
 
     double precision, parameter :: rho = dsqrt(two / five)
@@ -40,15 +41,31 @@ module parcel_ellipsoid
 
     contains
 
-        subroutine parcel_ellipsoid_allocate
-            allocate(Vetas(n_dim, max_num_parcels))
-            allocate(Vtaus(n_dim, max_num_parcels))
+        subroutine parcel_ellipsoid_resize(new_size)
+            integer, intent(in) :: new_size
+
+            call resize_array(Vetas, new_size)
+            call resize_array(Vtaus, new_size)
+
+        end subroutine parcel_ellipsoid_resize
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine parcel_ellipsoid_allocate(num)
+            integer, intent(in) :: num
+
+            allocate(Vetas(3, num))
+            allocate(Vtaus(3, num))
         end subroutine parcel_ellipsoid_allocate
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         subroutine parcel_ellipsoid_deallocate
             deallocate(Vetas)
             deallocate(Vtaus)
         end subroutine parcel_ellipsoid_deallocate
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         ! Obtain the parcel shape matrix.
         ! @param[in] B = (B11, B12, B13, B22, B23)
@@ -69,6 +86,8 @@ module parcel_ellipsoid
             U(3, 2) = U(2, 3)
             U(3, 3) = get_B33(B, volume)
         end function get_full_matrix
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         ! Obtain all eigenvalues sorted in descending order
         ! @param[in] B = (B11, B12, B13, B22, B23)
@@ -93,6 +112,8 @@ module parcel_ellipsoid
 #endif
         end function get_eigenvalues
 
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
         function get_determinant(B, volume) result(detB)
             double precision, intent(in) :: B(5)
             double precision, intent(in) :: volume
@@ -104,6 +125,8 @@ module parcel_ellipsoid
                  - B(I_B12) * (B(I_B12) * B33 - B(I_B13) * B(I_B23))      &
                  + B(I_B13) * (B(I_B12) * B(I_B23) - B(I_B13) * B(I_B22))
         end function get_determinant
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         ! Obtain the normalized eigenvectors.
         ! The eigenvector V(:, j) belongs to the j-th
@@ -128,6 +151,8 @@ module parcel_ellipsoid
             endif
 #endif
         end function get_eigenvectors
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         ! Compute the eigenvalue decomposition B = V^T * D * V
         ! where D has the eigenvalues on its diagonal
@@ -157,6 +182,8 @@ module parcel_ellipsoid
 #endif
         end subroutine diagonalise
 
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
         ! Obtain the B33 matrix element
         ! @param[in] B = (B11, B12, B13, B22, B23)
         ! @param[in] volume of the parcel
@@ -181,6 +208,8 @@ module parcel_ellipsoid
 
         end function get_B33
 
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
         ! Obtain the product of the semi-minor and semi-major axis.
         ! @param[in] volume of the parcel
         ! @returns abc = 3 * volume / (4 * pi)
@@ -190,6 +219,8 @@ module parcel_ellipsoid
 
             abc = f34 * volume * fpi
         end function get_abc
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         ! Obtain the aspect ratio a/c of the parcel(s).
         ! @param[in] D eigenvalues sorted in descending order
@@ -201,6 +232,8 @@ module parcel_ellipsoid
 
             lam = dsqrt(D(I_X) / D(I_Z))
         end function get_aspect_ratio
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         ! Obtain the ellipse support points for par2grid and grid2par
         ! @param[in] position vector of the parcel
@@ -254,6 +287,8 @@ module parcel_ellipsoid
                              + Vtau * sintheta(j)
             enddo
         end function get_ellipsoid_points
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         function get_angles(B, volume) result(angles)
             double precision, intent(in) :: B(5)

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -12,7 +12,6 @@ module parcel_ellipsoid
                         , fpi4  &
                         , f34   &
                         , zero  &
-                        , one   &
                         , two   &
                         , three &
                         , five  &
@@ -301,9 +300,6 @@ module parcel_ellipsoid
 
             ! azimuthal angle
             angles(I_X) = datan2(evec(I_Y, I_X), evec(I_X, I_X))
-
-            ! restrict to -1, 1
-            evec(I_Z, I_Z) = max(-one, min(one, evec(I_Z, I_Z)))
 
             ! polar angle
             angles(I_Y) = dasin(evec(I_Z, I_Z))

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -36,7 +36,7 @@ module parcel_ellipsoid
                         , I_B22 = 4 & ! index for B22 matrix component
                         , I_B23 = 5   ! index for B23 matrix component
 
-    private :: rho, f3pi4, f5pi4, f7pi4, costheta, sintheta, get_upper_triangular, Vetas, Vtaus
+    private :: rho, f3pi4, f5pi4, f7pi4, costheta, sintheta, get_full_matrix, Vetas, Vtaus
 
     contains
 
@@ -54,7 +54,7 @@ module parcel_ellipsoid
         ! @param[in] B = (B11, B12, B13, B22, B23)
         ! @param[in] volume of the parcel
         ! @returns the upper trinagular matrix
-        function get_upper_triangular(B, volume) result(U)
+        function get_full_matrix(B, volume) result(U)
             double precision, intent(in) :: B(5)
             double precision, intent(in) :: volume
             double precision             :: U(n_dim, n_dim)
@@ -62,10 +62,13 @@ module parcel_ellipsoid
             U(1, 1) = B(I_B11)
             U(1, 2) = B(I_B12)
             U(1, 3) = B(I_B13)
+            U(2, 1) = U(1, 2)
             U(2, 2) = B(I_B22)
             U(2, 3) = B(I_B23)
+            U(3, 1) = U(1, 3)
+            U(3, 2) = U(2, 3)
             U(3, 3) = get_B33(B, volume)
-        end function get_upper_triangular
+        end function get_full_matrix
 
         ! Obtain all eigenvalues sorted in descending order
         ! @param[in] B = (B11, B12, B13, B22, B23)
@@ -77,7 +80,7 @@ module parcel_ellipsoid
             double precision             :: U(n_dim, n_dim)
             double precision             :: D(n_dim)
 
-            U = get_upper_triangular(B, volume)
+            U = get_full_matrix(B, volume)
 
             call scherzinger_eigenvalues(U, D)
 
@@ -113,7 +116,7 @@ module parcel_ellipsoid
             double precision, intent(in) :: volume
             double precision             :: U(n_dim, n_dim), D(n_dim), V(n_dim, n_dim)
 
-            U = get_upper_triangular(B, volume)
+            U = get_full_matrix(B, volume)
 
             call scherzinger_diagonalise(U, D, V)
 
@@ -141,7 +144,7 @@ module parcel_ellipsoid
             double precision, intent(out) :: D(n_dim), V(n_dim, n_dim)
             double precision              :: U(n_dim, n_dim)
 
-            U = get_upper_triangular(B, volume)
+            U = get_full_matrix(B, volume)
 
             call scherzinger_diagonalise(U, D, V)
 

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -41,11 +41,11 @@ module parcel_ellipsoid
 
     contains
 
-        subroutine parcel_ellipsoid_resize(new_size)
-            integer, intent(in) :: new_size
+        subroutine parcel_ellipsoid_resize(new_size, old_size)
+            integer, intent(in) :: new_size, old_size
 
-            call resize_array(Vetas, new_size)
-            call resize_array(Vtaus, new_size)
+            call resize_array(Vetas, new_size, old_size)
+            call resize_array(Vtaus, new_size, old_size)
 
         end subroutine parcel_ellipsoid_resize
 

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -41,11 +41,11 @@ module parcel_ellipsoid
 
     contains
 
-        subroutine parcel_ellipsoid_resize(new_size, old_size)
-            integer, intent(in) :: new_size, old_size
+        subroutine parcel_ellipsoid_resize(new_size, n_copy)
+            integer, intent(in) :: new_size, n_copy
 
-            call resize_array(Vetas, new_size, old_size)
-            call resize_array(Vtaus, new_size, old_size)
+            call resize_array(Vetas, new_size, n_copy)
+            call resize_array(Vtaus, new_size, n_copy)
 
         end subroutine parcel_ellipsoid_resize
 

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -12,6 +12,7 @@ module parcel_ellipsoid
                         , fpi4  &
                         , f34   &
                         , zero  &
+                        , one   &
                         , two   &
                         , three &
                         , five  &
@@ -300,6 +301,9 @@ module parcel_ellipsoid
 
             ! azimuthal angle
             angles(I_X) = datan2(evec(I_Y, I_X), evec(I_X, I_X))
+
+            ! restrict to -1, 1
+            evec(I_Z, I_Z) = max(-one, min(one, evec(I_Z, I_Z)))
 
             ! polar angle
             angles(I_Y) = dasin(evec(I_Z, I_Z))

--- a/src/3d/parcels/parcel_init.f90
+++ b/src/3d/parcels/parcel_init.f90
@@ -148,7 +148,7 @@ module parcel_init
 
             ! do refining by splitting
             do while (lam >= parcel%lambda_max)
-                call parcel_split(parcels, parcel%lambda_max)
+                call parcel_split
                 evals = get_eigenvalues(parcels%B(1, :), parcels%volume(1))
                 lam = dsqrt(evals(1) / evals(3))
             end do

--- a/src/3d/parcels/parcel_mpi.f90
+++ b/src/3d/parcels/parcel_mpi.f90
@@ -1,0 +1,369 @@
+module parcel_mpi
+    use mpi_layout
+    use mpi_utils, only : mpi_exit_on_error     &
+                        , mpi_check_for_message &
+                        , mpi_check_for_error
+    use mpi_tags
+#ifndef NDEBUG
+    use mpi_collectives, only : mpi_blocking_reduce
+#endif
+    use fields, only : get_index_periodic
+    use merge_sort, only : msort
+    use parameters, only : vmin, vcell, nz
+    use parcel_container, only : n_par_attrib       &
+                               , parcel_pack        &
+                               , parcel_unpack      &
+                               , parcel_delete      &
+                               , n_parcels          &
+#ifndef NDEBUG
+                               , n_total_parcels    &
+#endif
+                               , parcels
+    implicit none
+
+    private
+
+    integer, allocatable, dimension(:), target :: north_pid, south_pid, west_pid, east_pid, &
+                                                  northwest_pid, northeast_pid,             &
+                                                  southwest_pid, southeast_pid
+    double precision, allocatable, dimension(:), target :: north_buf, south_buf, west_buf, east_buf, &
+                                                           northwest_buf, northeast_buf,             &
+                                                           southwest_buf, southeast_buf
+    integer, allocatable, dimension(:) :: invalid
+
+    ! we have 8 neighbours
+    integer :: n_parcel_sends(8)
+
+    public :: parcel_communicate,           &
+              n_parcel_sends,               &
+              north_pid,                    &
+              south_pid,                    &
+              west_pid,                     &
+              east_pid,                     &
+              northwest_pid,                &
+              northeast_pid,                &
+              southwest_pid,                &
+              southeast_pid,                &
+              north_buf,                    &
+              south_buf,                    &
+              west_buf,                     &
+              east_buf,                     &
+              northwest_buf,                &
+              northeast_buf,                &
+              southwest_buf,                &
+              southeast_buf,                &
+              invalid,                      &
+              allocate_parcel_buffers,      &
+              deallocate_parcel_buffers,    &
+              allocate_parcel_id_buffers,   &
+              deallocate_parcel_id_buffers, &
+              get_parcel_buffer_ptr,        &
+              communicate_parcels
+
+    contains
+
+        ! We follow here PMPIC
+        ! https://github.com/EPCCed/pmpic/blob/master/model_core/src/parcels/haloswap.F90
+        ! git sha: 4a77642ef82096a770324f5f1dc587ce121065ab
+        subroutine get_parcel_buffer_ptr(dir, pid_ptr, buf_ptr)
+            integer,                                 intent(in)  :: dir
+            integer,          dimension(:), pointer, intent(out) :: pid_ptr
+            double precision, dimension(:), pointer, intent(out) :: buf_ptr
+
+            select case (dir)
+                case (MPI_NORTH)
+                    pid_ptr => north_pid
+                    buf_ptr => north_buf
+                case (MPI_SOUTH)
+                    pid_ptr => south_pid
+                    buf_ptr => south_buf
+                case (MPI_WEST)
+                    pid_ptr => west_pid
+                    buf_ptr => west_buf
+                case (MPI_EAST)
+                    pid_ptr => east_pid
+                    buf_ptr => east_buf
+                case (MPI_NORTHWEST)
+                    pid_ptr => northwest_pid
+                    buf_ptr => northwest_buf
+                case (MPI_NORTHEAST)
+                    pid_ptr => northeast_pid
+                    buf_ptr => northeast_buf
+                case (MPI_SOUTHWEST)
+                    pid_ptr => southwest_pid
+                    buf_ptr => southwest_buf
+                case (MPI_SOUTHEAST)
+                    pid_ptr => southeast_pid
+                    buf_ptr => southeast_buf
+                case default
+                    call mpi_exit_on_error(&
+                        "in parcel_mpi::get_parcel_buffer_ptr: No valid direction.")
+            end select
+
+        end subroutine get_parcel_buffer_ptr
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine parcel_communicate(pindex)
+            integer, optional, intent(in)           :: pindex(:)
+
+            ! We only must store the parcel indices (therefore 1) and
+            ! also allocate the buffer for invalid parcels. (therefore .true.)
+            call allocate_parcel_id_buffers(1, .true.)
+
+            ! figure out where parcels go
+            call locate_parcels(pindex)
+
+            call allocate_parcel_buffers(n_par_attrib)
+
+            call communicate_parcels
+
+            call deallocate_parcel_id_buffers
+
+            call deallocate_parcel_buffers
+
+        end subroutine parcel_communicate
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine communicate_parcels
+            integer,          dimension(:), pointer :: pid
+            double precision, dimension(:), pointer :: send_buf
+            double precision, allocatable           :: recv_buf(:)
+            type(MPI_Request)                       :: requests(8)
+            type(MPI_Status)                        :: recv_status, send_statuses(8)
+            integer                                 :: n_total_sends, n
+            integer                                 :: recv_count
+            integer                                 :: recv_size, send_size
+
+            do n = 1, 8
+                call get_parcel_buffer_ptr(n, pid, send_buf)
+
+                send_size = n_parcel_sends(n) * n_par_attrib
+
+                if (n_parcel_sends(n) > 0) then
+                    call parcel_pack(pid, n_parcel_sends(n), send_buf)
+                endif
+
+                call MPI_Isend(send_buf(1:send_size),   &
+                               send_size,               &
+                               MPI_DOUBLE_PRECISION,    &
+                               neighbours(n)%rank,      &
+                               SEND_NEIGHBOUR_TAG(n),   &
+                               comm%cart,               &
+                               requests(n),             &
+                               comm%err)
+
+                call mpi_check_for_error("in MPI_Isend of parcel_mpi::communicate_parcels.")
+            enddo
+
+            do n = 1, 8
+
+                ! check for incoming messages
+                call mpi_check_for_message(neighbours(n)%rank,      &
+                                           RECV_NEIGHBOUR_TAG(n),   &
+                                           recv_size)
+
+                allocate(recv_buf(recv_size))
+
+                call MPI_Recv(recv_buf(1:recv_size),    &
+                              recv_size,                &
+                              MPI_DOUBLE_PRECISION,     &
+                              neighbours(n)%rank,       &
+                              RECV_NEIGHBOUR_TAG(n),    &
+                              comm%cart,                &
+                              recv_status,              &
+                              comm%err)
+
+                call mpi_check_for_error("in MPI_Recv of parcel_mpi::communicate_parcels.")
+
+                if (mod(recv_size, n_par_attrib) /= 0) then
+                    call mpi_exit_on_error("parcel_mpi::communicate_parcels: Receiving wrong count.")
+                endif
+
+                recv_count = recv_size / n_par_attrib
+
+                if (recv_count > 0) then
+                    call parcel_unpack(recv_count, recv_buf)
+                endif
+
+                deallocate(recv_buf)
+            enddo
+
+            call MPI_Waitall(8,                 &
+                            requests,           &
+                            send_statuses,      &
+                            comm%err)
+
+            call mpi_check_for_error("in MPI_Waitall of parcel_mpi::communicate_parcels.")
+
+            ! delete parcel that we sent
+            n_total_sends = sum(n_parcel_sends)
+            call parcel_delete(invalid, n_total_sends)
+
+#ifndef NDEBUG
+            n = n_parcels
+            call mpi_blocking_reduce(n, MPI_SUM)
+            if ((comm%rank == comm%master) .and. (.not. n == n_total_parcels)) then
+                call mpi_exit_on_error(&
+                    "in parcel_mpi::communicate_parcels: We lost parcels.")
+            endif
+#endif
+        end subroutine communicate_parcels
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine locate_parcels(pindex)
+            integer, optional, intent(in) :: pindex(:)
+            integer                       :: i, j, k, n, nb, m, iv, np, l
+
+            ! reset the number of sends
+            n_parcel_sends(:) = 0
+
+            np = n_parcels
+
+            if (present(pindex)) then
+                np = size(pindex)
+            endif
+
+            iv = 1
+            do n = 1, np
+
+                l = n
+                if (present(pindex)) then
+                    l = pindex(n)
+                endif
+
+                call get_index_periodic(parcels%position(:, l), i, j, k)
+
+                nb = get_neighbour(i, j)
+
+                select case (nb)
+                    case (MPI_NONE)
+                        ! do nothing
+                        cycle
+                    case (MPI_NORTH)
+                        m = n_parcel_sends(nb) + 1
+                        north_pid(m) = l
+                    case (MPI_SOUTH)
+                        m = n_parcel_sends(nb) + 1
+                        south_pid(m) = l
+                    case (MPI_WEST)
+                        m = n_parcel_sends(nb) + 1
+                        west_pid(m) = l
+                    case (MPI_EAST)
+                        m = n_parcel_sends(nb) + 1
+                        east_pid(m) = l
+                    case (MPI_NORTHWEST)
+                        m = n_parcel_sends(nb) + 1
+                        northwest_pid(m) = l
+                    case (MPI_NORTHEAST)
+                        m = n_parcel_sends(nb) + 1
+                        northeast_pid(m) = l
+                    case (MPI_SOUTHWEST)
+                        m = n_parcel_sends(nb) + 1
+                        southwest_pid(m) = l
+                    case (MPI_SOUTHEAST)
+                        m = n_parcel_sends(nb) + 1
+                        southeast_pid(m) = l
+                    case default
+                        call mpi_exit_on_error("locate_parcels: Parcel was not assigned properly.")
+                end select
+
+                invalid(iv) = l
+                n_parcel_sends(nb) = n_parcel_sends(nb) + 1
+                iv = iv + 1
+            enddo
+
+        end subroutine locate_parcels
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine allocate_parcel_id_buffers(n_ids, l_invalid)
+            integer, intent(in) :: n_ids
+            logical, intent(in) :: l_invalid
+            integer             :: nc, ub, n_max
+
+            n_parcel_sends = 0
+
+            ! upper bound (ub) of parcels per cell
+            ub = ceiling(vcell / vmin)
+
+            ! number of cells sharing with north and south neighbour
+            nc = (box%hi(1) - box%lo(1) + 1) * nz
+            n_max = 2 * nc
+
+            allocate(north_pid(nc * ub * n_ids))
+            allocate(south_pid(nc * ub * n_ids))
+
+            ! number of cells sharing with west and east neighbour
+            nc = (box%hi(2) - box%lo(2) + 1) * nz
+            n_max = n_max + 2 * nc
+
+            allocate(west_pid(nc * ub * n_ids))
+            allocate(east_pid(nc * ub * n_ids))
+
+            ! number of cells sharing with corner neighbours
+            nc = nz
+            n_max = n_max + 4 * nc
+
+            allocate(northwest_pid(nc * ub * n_ids))
+            allocate(northeast_pid(nc * ub * n_ids))
+            allocate(southwest_pid(nc * ub * n_ids))
+            allocate(southeast_pid(nc * ub * n_ids))
+
+            if (l_invalid) then
+                ! Note: This buffer needs to have start index 0 because of the parcel delete routine.
+                !       However, this first array element is never assigned any value.
+                allocate(invalid(0:n_max * ub * n_ids))
+            endif
+
+        end subroutine allocate_parcel_id_buffers
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine deallocate_parcel_id_buffers
+            deallocate(north_pid)
+            deallocate(south_pid)
+            deallocate(west_pid)
+            deallocate(east_pid)
+
+            deallocate(northwest_pid)
+            deallocate(northeast_pid)
+            deallocate(southwest_pid)
+            deallocate(southeast_pid)
+
+            if (allocated(invalid)) then
+                deallocate(invalid)
+            endif
+        end subroutine deallocate_parcel_id_buffers
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine allocate_parcel_buffers(n_attributes)
+            integer, intent(in) :: n_attributes
+
+            allocate(north_buf(n_parcel_sends(MPI_NORTH) * n_attributes))
+            allocate(northeast_buf(n_parcel_sends(MPI_NORTHEAST) * n_attributes))
+            allocate(east_buf(n_parcel_sends(MPI_EAST) * n_attributes))
+            allocate(southeast_buf(n_parcel_sends(MPI_SOUTHEAST) * n_attributes))
+            allocate(south_buf(n_parcel_sends(MPI_SOUTH) * n_attributes))
+            allocate(southwest_buf(n_parcel_sends(MPI_SOUTHWEST) * n_attributes))
+            allocate(west_buf(n_parcel_sends(MPI_WEST) * n_attributes))
+            allocate(northwest_buf(n_parcel_sends(MPI_NORTHWEST) * n_attributes))
+        end subroutine allocate_parcel_buffers
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine deallocate_parcel_buffers
+            deallocate(north_buf)
+            deallocate(northeast_buf)
+            deallocate(east_buf)
+            deallocate(southeast_buf)
+            deallocate(south_buf)
+            deallocate(southwest_buf)
+            deallocate(west_buf)
+            deallocate(northwest_buf)
+        end subroutine deallocate_parcel_buffers
+
+end module parcel_mpi

--- a/src/3d/parcels/parcel_split.f90
+++ b/src/3d/parcels/parcel_split.f90
@@ -51,7 +51,7 @@ module parcel_split_mod
                 ! evaluate maximum aspect ratio (a2 >= b2 >= c2)
                 lam = get_aspect_ratio(D)
 
-                if (lam <= threshold .and. D(1) < amax ** 2) then
+                if (lam < threshold .and. D(1) < amax ** 2) then
                     cycle
                 endif
 

--- a/src/3d/parcels/parcel_split.f90
+++ b/src/3d/parcels/parcel_split.f90
@@ -47,7 +47,6 @@ module parcel_split_mod
             call start_timer(split_timer)
 
             ! Estimate final number of parcels based on previous number of splits:
-            ! If the est
             n_estimate = nint(dble(sum(n_previous_splits)) / dble(size(n_previous_splits))) &
                        + n_parcels
 

--- a/src/3d/parcels/parcel_split.f90
+++ b/src/3d/parcels/parcel_split.f90
@@ -51,7 +51,7 @@ module parcel_split_mod
                 ! evaluate maximum aspect ratio (a2 >= b2 >= c2)
                 lam = get_aspect_ratio(D)
 
-                if (lam <= threshold .and. D(1) <= amax ** 2) then
+                if (lam <= threshold .and. D(1) < amax ** 2) then
                     cycle
                 endif
 

--- a/src/3d/parcels/parcel_split.f90
+++ b/src/3d/parcels/parcel_split.f90
@@ -24,7 +24,7 @@ module parcel_split_mod
     ! current index for "running average"
     integer, protected :: ri = 0
 
-    private :: dh, n_previous_splits, ri
+    private :: dh, n_previous_splits, ri, adapt_container_size
 
     integer :: split_timer
 
@@ -34,17 +34,13 @@ module parcel_split_mod
 
     contains
 
-        ! Split elongated parcels (semi-major axis larger than amax) or
-        ! parcels with aspect ratios larger than parcel%lambda_max.
-        subroutine parcel_split
-            double precision     :: B(5)
-            double precision     :: vol, lam
-            double precision     :: D(3), V(3, 3)
-            integer              :: last_index
-            integer              :: n, n_thread_loc
+        ! Adapt the container size. This routine is invoked before
+        ! the actual splitting. It estimstes the final number of parcels
+        ! according to previous split calls. If the estimated number exceeds
+        ! the container size, a container resize operation is invoked. If the
+        ! estimated number is below a threshold, the container size is reduced.
+        subroutine adapt_container_size
             integer              :: n_estimate, shrunk_size, grown_size
-
-            call start_timer(split_timer)
 
             ! Estimate final number of parcels based on previous number of splits:
             n_estimate = nint(dble(sum(n_previous_splits)) / dble(size(n_previous_splits))) &
@@ -58,6 +54,24 @@ module parcel_split_mod
             else if (n_estimate < shrunk_size) then
                 call parcel_resize(shrunk_size)
             endif
+
+        end subroutine adapt_container_size
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        ! Split elongated parcels (semi-major axis larger than amax) or
+        ! parcels with aspect ratios larger than parcel%lambda_max.
+        subroutine parcel_split
+            double precision     :: B(5)
+            double precision     :: vol, lam
+            double precision     :: D(3), V(3, 3)
+            integer              :: last_index
+            integer              :: n, n_thread_loc
+            integer              :: n_estimate, shrunk_size, grown_size
+
+            call adapt_container_size
+
+            call start_timer(split_timer)
 
             last_index = n_parcels
 

--- a/src/3d/parcels/parcel_split.f90
+++ b/src/3d/parcels/parcel_split.f90
@@ -4,7 +4,7 @@
 module parcel_split_mod
     use options, only : verbose
     use constants, only : pi, three, five, f12, f34
-    use parameters, only : vmax
+    use parameters, only : amax
     use parcel_container, only : parcel_container_type, n_parcels
     use parcel_bc, only : apply_reflective_bc
     use parcel_ellipsoid, only : diagonalise, get_aspect_ratio
@@ -23,7 +23,7 @@ module parcel_split_mod
 
     contains
 
-        ! Split large parcels (volumes larger than vmax) or
+        ! Split elongated parcels (semi-major axis larger than amax) or
         ! parcels with aspect ratios larger than the threshold.
         ! @param[inout] parcels
         ! @param[in] threshold is the largest allowed aspect ratio
@@ -51,7 +51,7 @@ module parcel_split_mod
                 ! evaluate maximum aspect ratio (a2 >= b2 >= c2)
                 lam = get_aspect_ratio(D)
 
-                if (lam <= threshold .and. vol <= vmax) then
+                if (lam <= threshold .and. D(1) <= amax ** 2) then
                     cycle
                 endif
 

--- a/src/3d/parcels/parcel_split.f90
+++ b/src/3d/parcels/parcel_split.f90
@@ -48,10 +48,10 @@ module parcel_split_mod
 
             shrunk_size = nint(parcel%shrink_factor * max_num_parcels)
 
-            if (n_estimate > max_num_parcels) then
+            if (n_estimate > int(f34 * max_num_parcels)) then
                 grown_size = nint(parcel%grow_factor * max_num_parcels)
                 call parcel_resize(grown_size)
-            else if (n_estimate < shrunk_size) then
+            else if (n_estimate < int(f34 * shrunk_size)) then
                 call parcel_resize(shrunk_size)
             endif
 
@@ -136,7 +136,7 @@ module parcel_split_mod
             ! number of previous splits; used for calculating
             ! the running average for parcel container size adaption
             n_previous_splits(ri+1) = n_parcels - last_index
-            ri = mod(ri + 1, 10)
+            ri = mod(ri + 1, size(n_previous_splits))
 
             n_parcel_splits = n_parcel_splits + n_parcels - last_index
 

--- a/src/3d/parcels/parcel_split.f90
+++ b/src/3d/parcels/parcel_split.f90
@@ -42,7 +42,7 @@ module parcel_split_mod
             double precision     :: D(3), V(3, 3)
             integer              :: last_index
             integer              :: n, n_thread_loc
-            integer              :: n_estimate
+            integer              :: n_estimate, shrunk_size, grown_size
 
             call start_timer(split_timer)
 
@@ -50,9 +50,14 @@ module parcel_split_mod
             ! If the est
             n_estimate = nint(dble(sum(n_previous_splits)) / dble(size(n_previous_splits))) &
                        + n_parcels
+
+            shrunk_size = nint(parcel%shrink_factor * max_num_parcels)
+
             if (n_estimate > max_num_parcels) then
-                n_estimate = nint(parcel%grow_factor * max_num_parcels)
-                call parcel_resize(n_estimate)
+                grown_size = nint(parcel%grow_factor * max_num_parcels)
+                call parcel_resize(grown_size)
+            else if (n_estimate < shrunk_size) then
+                call parcel_resize(shrunk_size)
             endif
 
             last_index = n_parcels

--- a/src/3d/parcels/parcel_split.f90
+++ b/src/3d/parcels/parcel_split.f90
@@ -75,15 +75,14 @@ module parcel_split_mod
             ! we get additional "n_indices" parcels
             n_required = n_parcels + n_indices
 
-            shrunk_size = max(n_required, max_num_parcels)
-            shrunk_size = nint(parcel%shrink_factor * shrunk_size)
+            shrunk_size = nint(parcel%shrink_factor * n_required)
 
             call stop_timer(split_timer)
 
             if (n_required > max_num_parcels) then
                 grown_size = nint(parcel%grow_factor * n_required)
                 call parcel_resize(grown_size)
-            else if (n_required < int(f34 * shrunk_size)) then
+            else if (n_required < nint(f34 * shrunk_size)) then
                 call parcel_resize(shrunk_size)
             endif
 

--- a/src/3d/stepper/rk_utils.f90
+++ b/src/3d/stepper/rk_utils.f90
@@ -122,8 +122,11 @@ module rk_utils
                         strain(1, 1) = velgradg(iz, iy, ix, I_DUDX)                                   ! S11
                         strain(1, 2) = velgradg(iz, iy, ix, I_DUDY) + f12 * vortg(iz, iy, ix, I_Z)    ! S12
                         strain(1, 3) = velgradg(iz, iy, ix, I_DWDX) + f12 * vortg(iz, iy, ix, I_Y)    ! S13
+                        strain(2, 1) = strain(1, 2)
                         strain(2, 2) = velgradg(iz, iy, ix, I_DVDY)                                   ! S22
                         strain(2, 3) = velgradg(iz, iy, ix, I_DWDY) - f12 * vortg(iz, iy, ix, I_X)    ! S23
+                        strain(3, 1) = strain(1, 3)
+                        strain(3, 2) = strain(2, 3)
                         strain(3, 3) = -(velgradg(iz, iy, ix, I_DUDX) + velgradg(iz, iy, ix, I_DVDY)) ! S33
 
                         ! calculate its eigenvalues. The Jacobi solver

--- a/src/3d/stepper/rk_utils.f90
+++ b/src/3d/stepper/rk_utils.f90
@@ -1,4 +1,4 @@
-module rk4_utils
+module rk_utils
     use dimensions, only : n_dim, I_X, I_Y, I_Z
     use parcel_ellipsoid, only : get_B33, I_B11, I_B12, I_B13, I_B22, I_B23
     use fields, only : velgradg, tbuoyg, vortg, I_DUDX, I_DUDY, I_DVDY, I_DWDX, I_DWDY
@@ -191,4 +191,4 @@ module rk4_utils
             endif
         end function get_time_step
 
-end module rk4_utils
+end module rk_utils

--- a/src/3d/stepper/rk_utils.f90
+++ b/src/3d/stepper/rk_utils.f90
@@ -4,7 +4,7 @@ module rk_utils
     use fields, only : velgradg, tbuoyg, vortg, I_DUDX, I_DUDY, I_DVDY, I_DWDX, I_DWDY
     use constants, only : zero, one, two, f12
     use parameters, only : nx, ny, nz, dxi, vcell
-    use jacobi, only : jacobi_eigenvalues
+    use scherzinger, only : scherzinger_eigenvalues
 #ifdef ENABLE_VERBOSE
     use options, only : output
 #endif
@@ -128,7 +128,7 @@ module rk_utils
 
                         ! calculate its eigenvalues. The Jacobi solver
                         ! requires the upper triangular matrix only.
-                        call jacobi_eigenvalues(strain, D)
+                        call scherzinger_eigenvalues(strain, D)
 
                         ! we must take the largest eigenvalue in magnitude (absolute value)
                         gmax = max(gmax, maxval(abs(D)))

--- a/src/3d/utils/options.f90
+++ b/src/3d/utils/options.f90
@@ -24,6 +24,9 @@ module options
     ! field input file
     character(len=512)  :: field_file = ''
 
+    ! ls rk order
+    integer :: rk_order = 4
+
 
     type bndry_info
         ! the rms of the boundary zeta must be smaller than
@@ -106,7 +109,7 @@ module options
             logical :: exists = .false.
 
             ! namelist definitions
-            namelist /EPIC/ field_file, boundary, output, parcel, time
+            namelist /EPIC/ field_file, rk_order, boundary, output, parcel, time
 
             ! check whether file exists
             inquire(file=filename, exist=exists)
@@ -145,6 +148,8 @@ module options
             call write_netcdf_attribute(ncid, "verbose", verbose)
 #endif
             call write_netcdf_attribute(ncid, "field_file", field_file)
+
+            call write_netcdf_attribute(ncid, "rk_order", rk_order)
 
             call write_netcdf_attribute(ncid, "zeta_tol", boundary%zeta_tol)
             call write_netcdf_attribute(ncid, "l_ignore_bndry_zeta_flag", &

--- a/src/3d/utils/options.f90
+++ b/src/3d/utils/options.f90
@@ -76,9 +76,9 @@ module options
     !
     type parcel_type
         double precision :: size_factor      = 1.0d0    ! factor to increase max. number of parcels
-        double precision :: grow_factor      = 0.5d0    ! factor to increase the parcel container size
+        double precision :: grow_factor      = 1.2d0    ! factor to increase the parcel container size
                                                         ! in the parcel splitting routine
-        double precision :: shrink_factor    = 0.5d0    ! factor to reduce the parcel container size
+        double precision :: shrink_factor    = 0.8d0    ! factor to reduce the parcel container size
         integer          :: n_per_cell       = 8        ! number of parcels per cell (need to be a cube)
         double precision :: lambda_max       = four     ! max. ellipse aspect ratio a/b
         double precision :: min_vratio       = 40.0d0   ! minimum ratio of grid cell volume / parcel volume

--- a/src/3d/utils/options.f90
+++ b/src/3d/utils/options.f90
@@ -82,7 +82,6 @@ module options
         integer          :: correction_iters = 2        ! parcel correction iterations
         double precision :: gradient_pref    = 1.8d0    ! prefactor for gradient descent
         double precision :: max_compression  = 0.5d0    ! parameter for gradient descent (limits the shift in parcel position)
-        double precision :: max_vratio       = 4.913d0  ! maximum ratio of grid cell volume / parcel volume (1.7^3)
 
     end type parcel_type
 
@@ -165,7 +164,6 @@ module options
             call write_netcdf_attribute(ncid, "correction_iters", parcel%correction_iters)
             call write_netcdf_attribute(ncid, "gradient_pref", parcel%gradient_pref)
             call write_netcdf_attribute(ncid, "max_compression", parcel%max_compression)
-            call write_netcdf_attribute(ncid, "max_vratio", parcel%max_vratio)
 
             call write_netcdf_attribute(ncid, "parcel_freq", output%parcel_freq)
             call write_netcdf_attribute(ncid, "field_freq", output%field_freq)

--- a/src/3d/utils/options.f90
+++ b/src/3d/utils/options.f90
@@ -76,13 +76,15 @@ module options
     !
     type parcel_type
         double precision :: size_factor      = 1.0d0    ! factor to increase max. number of parcels
+        double precision :: grow_factor      = 0.5d0    ! factor to increase max. number of parcels
+                                                        ! in the parcel splitting routine
         integer          :: n_per_cell       = 8        ! number of parcels per cell (need to be a cube)
         double precision :: lambda_max       = four     ! max. ellipse aspect ratio a/b
         double precision :: min_vratio       = 40.0d0   ! minimum ratio of grid cell volume / parcel volume
         integer          :: correction_iters = 2        ! parcel correction iterations
         double precision :: gradient_pref    = 1.8d0    ! prefactor for gradient descent
-        double precision :: max_compression  = 0.5d0    ! parameter for gradient descent (limits the shift in parcel position)
-
+        double precision :: max_compression  = 0.5d0    ! parameter for gradient descent
+                                                        ! (limits the shift in parcel position)
     end type parcel_type
 
     type(parcel_type) :: parcel

--- a/src/3d/utils/options.f90
+++ b/src/3d/utils/options.f90
@@ -76,8 +76,9 @@ module options
     !
     type parcel_type
         double precision :: size_factor      = 1.0d0    ! factor to increase max. number of parcels
-        double precision :: grow_factor      = 0.5d0    ! factor to increase max. number of parcels
+        double precision :: grow_factor      = 0.5d0    ! factor to increase the parcel container size
                                                         ! in the parcel splitting routine
+        double precision :: shrink_factor    = 0.5d0    ! factor to reduce the parcel container size
         integer          :: n_per_cell       = 8        ! number of parcels per cell (need to be a cube)
         double precision :: lambda_max       = four     ! max. ellipse aspect ratio a/b
         double precision :: min_vratio       = 40.0d0   ! minimum ratio of grid cell volume / parcel volume

--- a/src/3d/utils/parameters.f90
+++ b/src/3d/utils/parameters.f90
@@ -135,7 +135,7 @@ module parameters
 
         vmin = vcell / parcel%min_vratio
 
-        amax = maxval(dx)
+        amax = minval(dx)
 
         max_num_parcels = int(nx * ny * nz * parcel%min_vratio * parcel%size_factor)
 

--- a/src/3d/utils/parameters.f90
+++ b/src/3d/utils/parameters.f90
@@ -226,6 +226,11 @@ module parameters
     end subroutine set_mesh_spacing
 
 
+    subroutine set_max_num_parcels(num)
+        integer, intent(in) :: num
+        max_num_parcels = num
+    end subroutine set_max_num_parcels
+
 #ifdef ENABLE_UNIT_TESTS
     subroutine set_vmin(val)
         double precision, intent(in) :: val

--- a/src/3d/utils/parameters.f90
+++ b/src/3d/utils/parameters.f90
@@ -72,8 +72,8 @@ module parameters
     ! minimum volume
     double precision, protected :: vmin
 
-    ! maximum volume
-    double precision, protected :: vmax
+    ! upper bound for major semi-axis (used for splitting)
+    double precision, protected :: amax
 
     ! maximum number of allowed parcels
     integer, protected :: max_num_parcels
@@ -134,7 +134,8 @@ module parameters
         hli = one / hl
 
         vmin = vcell / parcel%min_vratio
-        vmax = vcell / parcel%max_vratio
+
+        amax = maxval(dx)
 
         max_num_parcels = int(nx * ny * nz * parcel%min_vratio * parcel%size_factor)
 
@@ -231,11 +232,10 @@ module parameters
         vmin = val
     end subroutine set_vmin
 
-
-    subroutine set_vmax(val)
+    subroutine set_amax(val)
         double precision, intent(in) :: val
-        vmax = val
-    end subroutine set_vmax
+        amax = val
+    end subroutine set_amax
 #endif
 
 end module parameters

--- a/src/3d/utils/utils.f90
+++ b/src/3d/utils/utils.f90
@@ -77,7 +77,7 @@ module utils
             call par2grid
 
             ! need to be called in order to set initial time step;
-            ! this is also needed for the first ls-rk4 substep
+            ! this is also needed for the first ls-rk substep
             call vor2vel
 
             call vorticity_tendency

--- a/src/3d/utils/utils.f90
+++ b/src/3d/utils/utils.f90
@@ -70,9 +70,6 @@ module utils
         ! @param[in] t is the time
         subroutine write_last_step(t)
             double precision,  intent(in) :: t
-            double precision              :: velocity(3, n_parcels)
-            double precision              :: strain(5, n_parcels)
-            double precision              :: vorticity(3, n_parcels)
 
             call par2grid
 
@@ -82,9 +79,9 @@ module utils
 
             call vorticity_tendency
 
-            call grid2par(velocity, vorticity, strain)
+            call grid2par
 
-            call calculate_parcel_diagnostics(velocity)
+            call calculate_parcel_diagnostics
             call calculate_field_diagnostics
 
             call write_step(t, .true.)

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -5,6 +5,7 @@ AM_FCFLAGS = -I $(top_builddir)/src/		\
 lib_LTLIBRARIES = libepic_utils.la
 libepic_utils_la_SOURCES = 	\
 	iomanip.f90		\
+	armanip.f90		\
 	merge_sort.f90		\
 	constants.f90		\
 	timer.f90		\

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -8,7 +8,9 @@ libepic_utils_la_SOURCES = 	\
 	merge_sort.f90		\
 	constants.f90		\
 	timer.f90		\
+	linalg.f90		\
 	jacobi.f90		\
+	scherzinger.f90		\
 	ape_density.f90		\
 	physics.f90
 

--- a/src/utils/armanip.f90
+++ b/src/utils/armanip.f90
@@ -18,25 +18,25 @@ module armanip
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-        subroutine resize_array_1d(attr, new_size, copy_size)
+        subroutine resize_array_1d(attr, new_size, old_size)
             double precision, allocatable, intent(inout) :: attr(:)
             integer,                       intent(in)    :: new_size
-            integer, optional,             intent(in)    :: copy_size
+            integer, optional,             intent(in)    :: old_size
             double precision, allocatable                :: buffer(:)
-            integer                                      :: old_size
+            integer                                      :: copy_size
 
-            old_size = size(attr)
-            if (present(copy_size)) then
-                old_size = copy_size
+            copy_size = size(attr)
+            if (present(old_size)) then
+                copy_size = old_size
             endif
 
-            if (new_size < old_size) then
-                call mpi_exit_on_error("armanip::resize_array_1d: new_size < old_size")
+            if (new_size < copy_size) then
+                call mpi_exit_on_error("armanip::resize_array_1d: new_size < copy_size")
             endif
 
             allocate(buffer(new_size))
 
-            buffer(1:old_size) = attr(1:old_size)
+            buffer(1:copy_size) = attr(1:copy_size)
 
             call move_alloc(buffer, attr)
 
@@ -44,27 +44,27 @@ module armanip
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-        subroutine resize_array_2d(attr, new_size, copy_size)
+        subroutine resize_array_2d(attr, new_size, old_size)
             double precision, allocatable, intent(inout) :: attr(:, :)
             integer,                       intent(in)    :: new_size
-            integer, optional,             intent(in)    :: copy_size
+            integer, optional,             intent(in)    :: old_size
             double precision, allocatable                :: buffer(:, :)
-            integer                                      :: ncomp, old_size
+            integer                                      :: ncomp, copy_size
 
             ncomp = size(attr, dim=1)
-            old_size = size(attr, dim=2)
+            copy_size = size(attr, dim=2)
 
-            if (present(copy_size)) then
-                old_size = copy_size
+            if (present(old_size)) then
+                copy_size = old_size
             endif
 
-            if (new_size < old_size) then
-                call mpi_exit_on_error("armanip::resize_array_2d: new_size < old_size")
+            if (new_size < copy_size) then
+                call mpi_exit_on_error("armanip::resize_array_2d: new_size < copy_size")
             endif
 
             allocate(buffer(ncomp, new_size))
 
-            buffer(:, 1:old_size) = attr(:, 1:old_size)
+            buffer(:, 1:copy_size) = attr(:, 1:copy_size)
 
             call move_alloc(buffer, attr)
 

--- a/src/utils/armanip.f90
+++ b/src/utils/armanip.f90
@@ -18,16 +18,20 @@ module armanip
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-        subroutine resize_array_1d(attr, new_size, old_size)
+        ! Resize a one-dimensional array
+        ! @param[inout] attr the array
+        ! @param[in] new_size of the array
+        ! @param[in] n_copy number of elements to copy over
+        subroutine resize_array_1d(attr, new_size, n_copy)
             double precision, allocatable, intent(inout) :: attr(:)
             integer,                       intent(in)    :: new_size
-            integer, optional,             intent(in)    :: old_size
+            integer, optional,             intent(in)    :: n_copy
             double precision, allocatable                :: buffer(:)
             integer                                      :: copy_size
 
             copy_size = size(attr)
-            if (present(old_size)) then
-                copy_size = old_size
+            if (present(n_copy)) then
+                copy_size = n_copy
             endif
 
             if (new_size < copy_size) then
@@ -44,18 +48,22 @@ module armanip
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-        subroutine resize_array_2d(attr, new_size, old_size)
+        ! Resize a two-dimensional array
+        ! @param[inout] attr the array
+        ! @param[in] new_size of the array
+        ! @param[in] n_copy number of elements to copy over
+        subroutine resize_array_2d(attr, new_size, n_copy)
             double precision, allocatable, intent(inout) :: attr(:, :)
             integer,                       intent(in)    :: new_size
-            integer, optional,             intent(in)    :: old_size
+            integer, optional,             intent(in)    :: n_copy
             double precision, allocatable                :: buffer(:, :)
             integer                                      :: ncomp, copy_size
 
             ncomp = size(attr, dim=1)
             copy_size = size(attr, dim=2)
 
-            if (present(old_size)) then
-                copy_size = old_size
+            if (present(n_copy)) then
+                copy_size = n_copy
             endif
 
             if (new_size < copy_size) then

--- a/src/utils/armanip.f90
+++ b/src/utils/armanip.f90
@@ -31,7 +31,7 @@ module armanip
             endif
 
             if (new_size < copy_size) then
-                call mpi_exit_on_error("armanip::resize_array_1d: new_size < old_size")
+                call mpi_exit_on_error("armanip::resize_array_1d: new_size < copy_size")
             endif
 
             allocate(buffer(new_size))
@@ -59,7 +59,7 @@ module armanip
             endif
 
             if (new_size < copy_size) then
-                call mpi_exit_on_error("armanip::resize_array_2d: new_size < old_size")
+                call mpi_exit_on_error("armanip::resize_array_2d: new_size < copy_size")
             endif
 
             allocate(buffer(ncomp, new_size))

--- a/src/utils/armanip.f90
+++ b/src/utils/armanip.f90
@@ -2,7 +2,6 @@
 ! Module for common array manipulations.
 ! =============================================================================
 module armanip
-    use mpi_utils, only : mpi_exit_on_error
     implicit none
 
     private
@@ -35,7 +34,8 @@ module armanip
             endif
 
             if (new_size < copy_size) then
-                call mpi_exit_on_error("armanip::resize_array_1d: new_size < copy_size")
+                print *, "armanip::resize_array_1d: new_size < copy_size"
+                stop
             endif
 
             allocate(buffer(new_size))
@@ -67,7 +67,8 @@ module armanip
             endif
 
             if (new_size < copy_size) then
-                call mpi_exit_on_error("armanip::resize_array_2d: new_size < copy_size")
+                print *, "armanip::resize_array_2d: new_size < copy_size"
+                stop
             endif
 
             allocate(buffer(ncomp, new_size))

--- a/src/utils/armanip.f90
+++ b/src/utils/armanip.f90
@@ -1,0 +1,54 @@
+! =============================================================================
+! Module for common array manipulations.
+! =============================================================================
+module armanip
+    implicit none
+
+    private
+
+    interface resize_array
+        module procedure :: resize_array_1d
+        module procedure :: resize_array_2d
+    end interface resize_array
+
+    public :: resize_array
+
+    contains
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine resize_array_1d(attr, new_size)
+            double precision, allocatable, intent(inout) :: attr(:)
+            integer,           intent(in)    :: new_size
+            double precision, allocatable    :: buffer(:)
+            integer                          :: old_size
+
+            old_size = size(attr)
+
+            allocate(buffer(new_size))
+
+            buffer(1:old_size) = attr(1:old_size)
+
+            call move_alloc(buffer, attr)
+
+        end subroutine resize_array_1d
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        subroutine resize_array_2d(attr, new_size)
+            double precision, allocatable, intent(inout) :: attr(:, :)
+            integer,           intent(in)    :: new_size
+            double precision, allocatable    :: buffer(:, :)
+            integer                          :: shap(2)
+
+            shap = shape(attr)
+
+            allocate(buffer(new_size, shap(2)))
+
+            buffer(1:shap(1), :) = attr(1:shap(1), :)
+
+            call move_alloc(buffer, attr)
+
+        end subroutine resize_array_2d
+
+end module armanip

--- a/src/utils/armanip.f90
+++ b/src/utils/armanip.f90
@@ -18,25 +18,25 @@ module armanip
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-        subroutine resize_array_1d(attr, new_size, old_size)
+        subroutine resize_array_1d(attr, new_size, copy_size)
             double precision, allocatable, intent(inout) :: attr(:)
             integer,                       intent(in)    :: new_size
-            integer, optional,             intent(in)    :: old_size
+            integer, optional,             intent(in)    :: copy_size
             double precision, allocatable                :: buffer(:)
-            integer                                      :: copy_size
+            integer                                      :: old_size
 
-            copy_size = size(attr)
-            if (present(old_size)) then
-                copy_size = old_size
+            old_size = size(attr)
+            if (present(copy_size)) then
+                old_size = copy_size
             endif
 
-            if (new_size < copy_size) then
-                call mpi_exit_on_error("armanip::resize_array_1d: new_size < copy_size")
+            if (new_size < old_size) then
+                call mpi_exit_on_error("armanip::resize_array_1d: new_size < old_size")
             endif
 
             allocate(buffer(new_size))
 
-            buffer(1:copy_size) = attr(1:copy_size)
+            buffer(1:old_size) = attr(1:old_size)
 
             call move_alloc(buffer, attr)
 
@@ -44,27 +44,27 @@ module armanip
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-        subroutine resize_array_2d(attr, new_size, old_size)
+        subroutine resize_array_2d(attr, new_size, copy_size)
             double precision, allocatable, intent(inout) :: attr(:, :)
             integer,                       intent(in)    :: new_size
-            integer, optional,             intent(in)    :: old_size
+            integer, optional,             intent(in)    :: copy_size
             double precision, allocatable                :: buffer(:, :)
-            integer                                      :: ncomp, copy_size
+            integer                                      :: ncomp, old_size
 
             ncomp = size(attr, dim=1)
-            copy_size = size(attr, dim=2)
+            old_size = size(attr, dim=2)
 
-            if (present(old_size)) then
-                copy_size = old_size
+            if (present(copy_size)) then
+                old_size = copy_size
             endif
 
-            if (new_size < copy_size) then
-                call mpi_exit_on_error("armanip::resize_array_2d: new_size < copy_size")
+            if (new_size < old_size) then
+                call mpi_exit_on_error("armanip::resize_array_2d: new_size < old_size")
             endif
 
             allocate(buffer(ncomp, new_size))
 
-            buffer(:, 1:copy_size) = attr(:, 1:copy_size)
+            buffer(:, 1:old_size) = attr(:, 1:old_size)
 
             call move_alloc(buffer, attr)
 

--- a/src/utils/constants.f90
+++ b/src/utils/constants.f90
@@ -25,6 +25,7 @@ module constants
     double precision, parameter :: fpi    = one / pi
     double precision, parameter :: fpi2   = pi / two
     double precision, parameter :: fpi4   = pi / four
+    double precision, parameter :: fpi6   = pi / six
 
     double precision, parameter :: f32   = three / two
     double precision, parameter :: f34   = three / four

--- a/src/utils/linalg.f90
+++ b/src/utils/linalg.f90
@@ -1,0 +1,55 @@
+module linalg
+    use constants, only : zero, one
+    implicit none
+
+    contains
+
+    ! sign function (may be put in another module)
+    pure function signum(val) result(sgn)
+        double precision, intent(in) :: val
+        double precision             :: sgn
+
+        sgn = sign(one, val)
+
+        if (val == zero) then
+            sgn = zero
+        endif
+    end function signum
+
+    !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+    ! Calculates the cross product of two vectors 'a' and 'b'.
+    pure function cross(a, b) result(c)
+        double precision, intent(in) :: a(3), b(3)
+        double precision             :: c(3)
+
+        c(1) = a(2) * b(3) - a(3) * b(2)
+        c(2) = a(3) * b(1) - a(1) * b(3)
+        c(3) = a(1) * b(2) - a(2) * b(1)
+    end function cross
+
+    !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+    ! Calculates the trace of a matrix A.
+    pure function trace(A) result(tr)
+        double precision, intent(in) :: A(3, 3)
+        double precision             :: tr
+
+        tr = A(1, 1) + A(2, 2) + A(3, 3)
+
+    end function trace
+
+    !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+    ! Calculates the determinant of a matrix A.
+    pure function determinant(A) result(det)
+        double precision, intent(in) :: A(3, 3)
+        double precision             :: det
+
+        det = A(1, 1) * (A(2, 2) * A(3, 3) - A(2, 3) ** 2)      &
+            - A(1, 2) * (A(1, 2) * A(3, 3) - A(1, 3) * A(2, 3)) &
+            + A(1, 3) * (A(1, 2) * A(2, 3) - A(1, 3) * A(2, 2))
+
+    end function determinant
+
+end module linalg

--- a/src/utils/linalg.f90
+++ b/src/utils/linalg.f90
@@ -52,4 +52,22 @@ module linalg
 
     end function determinant
 
+    !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+    ! Calculates C = A * B where A and B are symmetric matrices
+    pure function dsymm(A, B) result(C)
+        double precision, intent(in) :: A(3, 3), B(3, 3)
+        double precision             :: C(3, 3)
+
+        C(1, 1) = A(1, 1) * B(1, 1) + A(1, 2) * B(1, 2) + A(1, 3) * B(1, 3)
+        C(1, 2) = A(1, 1) * B(1, 2) + A(1, 2) * B(2, 2) + A(1, 3) * B(2, 3)
+        C(1, 3) = A(1, 1) * B(1, 3) + A(1, 2) * B(2, 3) + A(1, 3) * B(3, 3)
+        C(2, 1) = A(1, 2) * B(1, 1) + A(2, 2) * B(1, 2) + A(2, 3) * B(1, 3)
+        C(2, 2) = A(1, 2) * B(1, 2) + A(2, 2) * B(2, 2) + A(2, 3) * B(2, 3)
+        C(2, 3) = A(1, 2) * B(1, 3) + A(2, 2) * B(2, 3) + A(2, 3) * B(3, 3)
+        C(3, 1) = A(1, 3) * B(1, 1) + A(2, 3) * B(1, 2) + A(3, 3) * B(1, 3)
+        C(3, 2) = A(1, 3) * B(1, 2) + A(2, 3) * B(2, 2) + A(3, 3) * B(2, 3)
+        C(3, 3) = A(1, 3) * B(1, 3) + A(2, 3) * B(2, 3) + A(3, 3) * B(3, 3)
+    end function dsymm
+
 end module linalg

--- a/src/utils/scherzinger.f90
+++ b/src/utils/scherzinger.f90
@@ -1,0 +1,274 @@
+! =============================================================================
+! Module to compute the eigenvalues and eigenvectors of 3x3 real symmetric
+! matrices. It uses the algorithm by Scherzinger and Dohrmann, according to
+!       Rutishauser, H. The Jacobi method for real symmetric matrices.
+!       Numer. Math. 9, 1-10 (1966). https://doi.org/10.1007/BF02165223
+! =============================================================================
+module scherzinger
+    use constants, only : hundred, one, zero, f12
+    implicit none
+
+    private
+        integer, parameter :: n = 3 ! we have 3x3 matrices
+        double precision, parameter :: atol = 1.0e-12
+
+    public :: scherzinger_diagonalise, scherzinger_eigenvalues
+
+    contains
+
+        ! Diagonalise a real symmetric 3x3 matrix A = V^T * D * V
+        ! where D is a diagonal matrix with the eigenvalues and
+        ! V is the eigenvector matrix. The eigenvalues are in
+        ! descending order.
+        ! The input matrix is overwritten and will be the diagonal
+        ! matrix storing the eigenvalues, V contains the eigenvectors.
+        ! The eigenvector V(:, i) belongs to eigenvalue A(i, i).
+        ! @param[inout] A real symmetric 3x3 matrix
+        ! @param[out] D eigenvalues in descending order
+        ! @param[out] V eigenvector matrix
+        pure subroutine scherzinger_diagonalise(A, D, V)
+            double precision, intent(inout) :: A(3, 3)
+            double precision, intent(out)   :: D(3)
+            double precision, intent(out)   :: V(3, 3)
+            double precision                :: AA(3, 3)
+            double precision                :: tmp, r(3, 3)
+            double precision                :: tr, j2, j3, alpha, eta(3)
+
+            ! sum of off-diagonal entries
+            tmp = dabs(A(1, 2)) + dabs(A(1, 3)) + dabs(A(2, 3))
+
+            ! check if a diagonal matrix
+            if (tmp < atol) then
+                V = zero
+                V(1, 1) = one
+                V(2, 2) = one
+                V(3, 3) = one
+                D(1) = A(1, 1)
+                D(2) = A(2, 2)
+                D(3) = A(3, 3)
+
+                call sort_eigenvalues(D)
+
+                return
+            endif
+
+            ! store initial diagonal values
+            D(1) = A(1, 1)
+            D(2) = A(2, 2)
+            D(3) = A(3, 3)
+
+            ! deviatoric matrix:
+            tr = trace(A)
+            tmp = f13 * tr
+            A(1, 1) = A(1, 1) - tmp
+            A(2, 2) = A(2, 2) - tmp
+            A(3, 3) = A(3, 3) - tmp
+
+            ! invariants j2 and j3:
+            AA = matmul(A, A)
+            j2 = f12 * trace(AA)
+            j3 = determinant(A)
+
+            ! angle:
+            alpha = f13 * acos(f12 * j3 * (three / j2) ** f32)
+
+            if (alpha > pi / 6.0d0) then
+                alpha = alpha + two * f13 * pi
+            endif
+
+            eta(1) = two * sqrt(f13 * j2) * cos(alpha)
+
+            r(:, 1) = (/ A(1, 1) - eta(1), A(2, 1),          A(3, 1)          /)
+            r(:, 2) = (/ A(1, 2),          A(2, 2) - eta(1), A(3, 2)          /)
+            r(:, 3) = (/ A(1, 3),          A(2, 3),          A(3, 3) - eta(1) /)
+
+            ! length of each r vector
+            rlen = norm2(r, dim=1)
+
+            i = maxloc(rlen, dim=1)
+
+            ! s1
+            if (i == 1) then
+                r(:, 1) = r(:, i) / rlen(i)
+            else if (i == 2) then
+                rlen = r(:, 2) / rlen(2)
+
+                r(:, 2) = r(:, 1)
+                r(:, 1) = rlen
+            else if (i == 3) then
+                rlen = r(:, 3) / rlen(3)
+
+                r(:, 3) = r(:, 1)
+                r(:, 1) = rlen
+
+            else
+                print *, "Error"
+                stop
+            endif
+
+            tmp = dot_product(r(:, 1), r(:, 2))
+            smp = dot_product(r(:, 1), r(:, 3))
+            r(:, 2) = r(:, 2) - tmp * r(:, 1)
+            r(:, 3) = r(:, 3) - smp * r(:, 1)
+
+            ! length of each r vector
+            rlen = norm2(r, dim=1)
+
+            i = maxloc(rlen(2:3), dim=1)
+
+            ! s2
+            r(:, 2) = r(:, i+1) / rlen(i+1)
+
+            V(:, 1) = cross(r(:, 1), r(:, 2))
+
+            rlen = matmul(A, r(:, 1))
+            s1As1 = dot_product(r(:, 1), rlen)
+            s2As1 = dot_product(r(:, 2), rlen)
+
+            rlen = matmul(A, r(:, 2))
+            s1As2 = dot_product(r(:, 1), rlen)
+            s2As2 = dot_product(r(:, 2), rlen)
+
+            tmp = s1As1 - s2As2
+            smp = s1As1 + s2As2
+
+            eta(2) = f12 * smp                                                    &
+                   - f12 * signum(tmp) * sqrt(tmp ** 2 + four * s1As2 * s2As1)
+
+            eta(3) = smp - eta(2)
+
+            A(1, 1) = D(1) - eta(2)
+            A(2, 2) = D(2) - eta(2)
+            A(3, 3) = D(3) - eta(2)
+
+            ! u1 and u2
+            rlen = matmul(A, r(:, 1))
+            r(:, 1) = rlen
+            rlen = matmul(A, r(:, 2))
+            r(:, 2) = rlen
+
+            rlen = norm2(r, dim=1)
+
+            i = maxloc(rlen(1:2), dim=1)
+
+            V(:, 3) = r(:, i) / rlen(i)
+
+
+            V(:, 2) = cross(V(:, 3), W(:, 1))
+            V(:, 3) = cross(V(:, 1), W(:, 2))
+
+            D = eta + f13 * tr
+
+
+            call sort_descending(D, V)
+
+        end subroutine scherzinger_diagonalise
+
+        ! Sort the eigenvalues in descending order.
+        ! It sorts the eigenvector matrix accordingly.
+        ! @param[inout] D eigenvalues
+        ! @param[inout] V eigenvector matrix
+        pure subroutine sort_descending(D, V)
+            double precision, intent(inout) :: D(n)
+            double precision, intent(inout) :: V(n, n)
+            double precision                :: teval, tevec(n)
+
+            if (D(2) > D(1)) then
+                teval = D(1)
+                D(1) = D(2)
+                D(2) = teval
+                tevec = V(:, 1)
+                V(:, 1) = V(:, 2)
+                V(:, 2) = tevec
+            endif
+
+            if (D(3) > D(2)) then
+                teval = D(2)
+                D(2) = D(3)
+                D(3) = teval
+                tevec = V(:, 2)
+                V(:, 2) = V(:, 3)
+                V(:, 3) = tevec
+            endif
+
+            if (D(2) > D(1)) then
+                teval = D(1)
+                D(1) = D(2)
+                D(2) = teval
+                tevec = V(:, 1)
+                V(:, 1) = V(:, 2)
+                V(:, 2) = tevec
+            endif
+        end subroutine sort_descending
+
+        ! Diagonalise a real symmetric 3x3 matrix A = V^T * D * V
+        ! where D is a diagonal matrix with the eigenvalues and
+        ! V is the eigenvector matrix. The eigenvalues are in
+        ! descending order.
+        ! The input matrix is overwritten, the diagonal
+        ! entries will be storing the eigenvalues
+        ! @param[inout] A real symmetric 3x3 matrix
+        ! @param[out] D eigenvalues in descending order
+        pure subroutine scherzinger_eigenvalues(A, D)
+            double precision, intent(inout) :: A(n, n)
+            double precision, intent(out)   :: D(n)
+            double precision                :: B(n), Z(n)
+            integer                         :: i, j
+            double precision                :: sm
+
+            ! initialise
+            do j = 1, n
+                D(j) = A(j, j)
+                B(j) = D(j)
+                Z(j) = zero
+            enddo
+
+            ! sum of off-diagonal entries
+            ! sm should convergence to zero
+            sm = dabs(A(1, 2)) + dabs(A(1, 3)) + dabs(A(2, 3))
+
+            do while (sm > atol)
+
+                do i = 1, n-1
+                    do j = i+1, n
+                        call apply_rotation(A, D, Z, i, j)
+                    enddo
+                enddo
+
+                B = B + Z
+                D = B
+                Z = zero
+                ! update sum of off-diagonals
+                sm = dabs(A(1, 2)) + dabs(A(1, 3)) + dabs(A(2, 3))
+            enddo
+
+            call sort_eigenvalues(D)
+
+        end subroutine scherzinger_eigenvalues
+
+        ! Sort the eigenvalues in descending order.
+        ! @param[inout] D eigenvalues
+        pure subroutine sort_eigenvalues(D)
+            double precision, intent(inout) :: D(n)
+            double precision                :: teval
+
+            if (D(2) > D(1)) then
+                teval = D(1)
+                D(1) = D(2)
+                D(2) = teval
+            endif
+
+            if (D(3) > D(2)) then
+                teval = D(2)
+                D(2) = D(3)
+                D(3) = teval
+            endif
+
+            if (D(2) > D(1)) then
+                teval = D(1)
+                D(1) = D(2)
+                D(2) = teval
+            endif
+        end subroutine sort_eigenvalues
+
+end module scherzinger

--- a/src/utils/scherzinger.f90
+++ b/src/utils/scherzinger.f90
@@ -8,13 +8,14 @@
 !       ISSN 0045-7825, https://doi.org/10.1016/j.cma.2008.03.031.
 ! =============================================================================
 module scherzinger
-    use constants, only : one, zero, f12, f13, f32, fpi6, three, pi, two, four
+    use constants, only : one, zero, f12, f13, f32, fpi6, three, pi, two, four, f23
     use linalg, only : cross, determinant, trace, signum
     implicit none
 
     private
         double precision, parameter :: atol = 1.0e-12
         double precision            :: r(3, 3)
+        double precision            :: eta(3)
 
     public :: scherzinger_diagonalise, scherzinger_eigenvalues
 
@@ -55,26 +56,28 @@ module scherzinger
                 return
             endif
 
-            call scherzinger_eigenvalues(A, D)
+            call scherzinger_eigenvalues(A, D, .false.)
 
+            A(1, 1) = A(1, 1) - eta(2)
+            A(2, 2) = A(2, 2) - eta(2)
+            A(3, 3) = A(3, 3) - eta(2)
+
+            ! first eigenvector, eq 21:
             V(:, 1) = cross(r(:, 1), r(:, 2))
 
-            ! u1 and u2
+            ! u1 and u2, eq 30:
             rlen = matmul(A, r(:, 1))
             r(:, 1) = rlen
             rlen = matmul(A, r(:, 2))
             r(:, 2) = rlen
 
             rlen = norm2(r, dim=1)
-
             i = maxloc(rlen(1:2), dim=1)
-
             V(:, 3) = r(:, i) / rlen(i)
 
-
+            ! second and third eigenvector, eq 31:
             V(:, 2) = cross(V(:, 3), V(:, 1))
             V(:, 3) = cross(V(:, 1), V(:, 2))
-
 
             call sort_descending(D, V)
 
@@ -121,45 +124,42 @@ module scherzinger
         ! where D is a diagonal matrix with the eigenvalues and
         ! V is the eigenvector matrix. The eigenvalues are in
         ! descending order.
-        ! The input matrix is overwritten, the diagonal
-        ! entries will be storing the eigenvalues
+        ! The input matrix is overwritten.
         ! @param[inout] A real symmetric 3x3 matrix
         ! @param[out] D eigenvalues in descending order
-        subroutine scherzinger_eigenvalues(A, D)
+        subroutine scherzinger_eigenvalues(A, D, l_sort)
             double precision, intent(inout) :: A(3, 3)
             double precision, intent(out)   :: D(3)
+            logical,          intent(in)    :: l_sort
             double precision                :: AA(3, 3)
-            double precision                :: tr, j2, j3, alpha, eta(3)
+            double precision                :: tr, j2, j3, alpha
             double precision                :: tmp, smp
             double precision                :: s1As1, s1As2, s2As1, s2As2, rlen(3)
             integer                         :: i
 
-            ! store initial diagonal values
-            D(1) = A(1, 1)
-            D(2) = A(2, 2)
-            D(3) = A(3, 3)
-
-            ! deviatoric matrix:
+            ! deviatoric matrix (eq 2):
             tr = trace(A)
             tmp = f13 * tr
             A(1, 1) = A(1, 1) - tmp
             A(2, 2) = A(2, 2) - tmp
             A(3, 3) = A(3, 3) - tmp
 
-            ! invariants j2 and j3:
+            ! invariants j2 and j3 (eq 5):
             AA = matmul(A, A)
             j2 = f12 * trace(AA)
             j3 = determinant(A)
 
-            ! angle:
+            ! angle (solve eq 7 for alpha):
             alpha = f13 * dacos(f12 * j3 * (three / j2) ** f32)
 
             if (alpha > fpi6) then
-                alpha = alpha + two * f13 * pi
+                alpha = alpha + f23 * pi
             endif
 
+            ! eq 6:
             eta(1) = two * dsqrt(f13 * j2) * dcos(alpha)
 
+            ! eq 19:
             r(:, 1) = (/ A(1, 1) - eta(1), A(2, 1),          A(3, 1)          /)
             r(:, 2) = (/ A(1, 2),          A(2, 2) - eta(1), A(3, 2)          /)
             r(:, 3) = (/ A(1, 3),          A(2, 3),          A(3, 3) - eta(1) /)
@@ -170,21 +170,18 @@ module scherzinger
             i = maxloc(rlen, dim=1)
 
             ! s1
-            if (i == 1) then
-                r(:, 1) = r(:, i) / rlen(i)
-            else if (i == 2) then
-                rlen = r(:, 2) / rlen(2)
+            rlen = r(:, i) / rlen(i)
 
+            if (i == 2) then
                 r(:, 2) = r(:, 1)
-                r(:, 1) = rlen
-            else
-                ! i == 3
-                rlen = r(:, 3) / rlen(3)
-
+            else if (i == 3) then
                 r(:, 3) = r(:, 1)
-                r(:, 1) = rlen
             endif
 
+            ! s1
+            r(:, 1) = rlen
+
+            ! t2 and t3 of eq 20:
             tmp = dot_product(r(:, 1), r(:, 2))
             smp = dot_product(r(:, 1), r(:, 3))
             r(:, 2) = r(:, 2) - tmp * r(:, 1)
@@ -193,38 +190,38 @@ module scherzinger
             ! length of each r vector
             rlen = norm2(r, dim=1)
 
-            i = maxloc(rlen(2:3), dim=1)
-
             ! s2
+            i = maxloc(rlen(2:3), dim=1)
             r(:, 2) = r(:, i+1) / rlen(i+1)
 
+            ! first eigenvector, eq 21:
 !             V(:, 1) = cross(r(:, 1), r(:, 2))
 
+            ! eq 22:
             rlen = matmul(A, r(:, 1))
             s1As1 = dot_product(r(:, 1), rlen)
             s2As1 = dot_product(r(:, 2), rlen)
 
             rlen = matmul(A, r(:, 2))
-            s1As2 = dot_product(r(:, 1), rlen)
+            s1As2 = s2As1 !dot_product(r(:, 1), rlen)
             s2As2 = dot_product(r(:, 2), rlen)
 
             tmp = s1As1 - s2As2
             smp = s1As1 + s2As2
 
+            ! second eigenvalue, eq 27:
             eta(2) = f12 * smp                                                    &
-                   - f12 * signum(tmp) * sqrt(tmp ** 2 + four * s1As2 * s2As1)
+                   - f12 * signum(tmp) * dsqrt(tmp ** 2 + four * s1As2 * s2As1)
 
+            !  third eigenvalue, eq 27:
             eta(3) = smp - eta(2)
 
-            A(1, 1) = D(1) - eta(2)
-            A(2, 2) = D(2) - eta(2)
-            A(3, 3) = D(3) - eta(2)
-
-
-
+            ! final eigenvalues:
             D = eta + f13 * tr
 
-            call sort_eigenvalues(D)
+            if (l_sort) then
+                call sort_eigenvalues(D)
+            endif
 
         end subroutine scherzinger_eigenvalues
 

--- a/src/utils/scherzinger.f90
+++ b/src/utils/scherzinger.f90
@@ -9,7 +9,7 @@
 ! =============================================================================
 module scherzinger
     use constants, only : one, zero, f12, f13, f32, fpi6, three, pi, two, four, f23
-    use linalg, only : cross, determinant, trace, signum
+    use linalg, only : cross, determinant, trace, signum, dsymm
     implicit none
 
     private
@@ -65,10 +65,7 @@ module scherzinger
             V(:, 1) = cross(r(:, 1), r(:, 2))
 
             ! u1 and u2, eq 30:
-            rlen = matmul(A, r(:, 1))
-            r(:, 1) = rlen
-            rlen = matmul(A, r(:, 2))
-            r(:, 2) = rlen
+            r(:, 1:2) = matmul(A, r(:, 1:2))
 
             rlen = norm2(r, dim=1)
             i = maxloc(rlen(1:2), dim=1)
@@ -156,7 +153,7 @@ module scherzinger
             A(3, 3) = A(3, 3) - tmp
 
             ! invariants j2 and j3 (eq 5):
-            AA = matmul(A, A)
+            AA = dsymm(A, A)
             j2 = f12 * trace(AA)
             j3 = determinant(A)
 
@@ -209,13 +206,12 @@ module scherzinger
 !             V(:, 1) = cross(r(:, 1), r(:, 2))
 
             ! eq 22:
-            rlen = matmul(A, r(:, 1))
-            s1As1 = dot_product(r(:, 1), rlen)
-            s2As1 = dot_product(r(:, 2), rlen)
-
-            rlen = matmul(A, r(:, 2))
+            AA(:, 1:2) = matmul(A, r(:, 1:2))
+            s1As1 = dot_product(r(:, 1), AA(:, 1))
+            s2As1 = dot_product(r(:, 2), AA(:, 1))
             s1As2 = s2As1 !dot_product(r(:, 1), rlen)
-            s2As2 = dot_product(r(:, 2), rlen)
+            s2As2 = dot_product(r(:, 2), AA(:, 2))
+
 
             tmp = s1As1 - s2As2
             smp = s1As1 + s2As2

--- a/src/utils/scherzinger.f90
+++ b/src/utils/scherzinger.f90
@@ -1,16 +1,20 @@
 ! =============================================================================
 ! Module to compute the eigenvalues and eigenvectors of 3x3 real symmetric
 ! matrices. It uses the algorithm by Scherzinger and Dohrmann, according to
-!       Rutishauser, H. The Jacobi method for real symmetric matrices.
-!       Numer. Math. 9, 1-10 (1966). https://doi.org/10.1007/BF02165223
+!       W.M. Scherzinger, C.R. Dohrmann,
+!       A robust algorithm for finding the eigenvalues and eigenvectors of
+!       3x3 symmetric matrices, Computer Methods in Applied Mechanics and
+!       Engineering, Volume 197, Issues 45-48, 2008, Pages 4007-4015,
+!       ISSN 0045-7825, https://doi.org/10.1016/j.cma.2008.03.031.
 ! =============================================================================
 module scherzinger
-    use constants, only : hundred, one, zero, f12
+    use constants, only : one, zero, f12, f13, f32, fpi6, three, pi, two, four
+    use linalg, only : cross, determinant, trace, signum
     implicit none
 
     private
-        integer, parameter :: n = 3 ! we have 3x3 matrices
         double precision, parameter :: atol = 1.0e-12
+        double precision            :: r(3, 3)
 
     public :: scherzinger_diagonalise, scherzinger_eigenvalues
 
@@ -20,19 +24,18 @@ module scherzinger
         ! where D is a diagonal matrix with the eigenvalues and
         ! V is the eigenvector matrix. The eigenvalues are in
         ! descending order.
-        ! The input matrix is overwritten and will be the diagonal
-        ! matrix storing the eigenvalues, V contains the eigenvectors.
-        ! The eigenvector V(:, i) belongs to eigenvalue A(i, i).
+        ! The input matrix is overwritten, V contains the eigenvectors.
+        ! The eigenvector V(:, i) belongs to eigenvalue D(i).
         ! @param[inout] A real symmetric 3x3 matrix
         ! @param[out] D eigenvalues in descending order
         ! @param[out] V eigenvector matrix
-        pure subroutine scherzinger_diagonalise(A, D, V)
+        subroutine scherzinger_diagonalise(A, D, V)
             double precision, intent(inout) :: A(3, 3)
             double precision, intent(out)   :: D(3)
             double precision, intent(out)   :: V(3, 3)
-            double precision                :: AA(3, 3)
-            double precision                :: tmp, r(3, 3)
-            double precision                :: tr, j2, j3, alpha, eta(3)
+            double precision                :: tmp
+            double precision                :: rlen(3)
+            integer                         :: i
 
             ! sum of off-diagonal entries
             tmp = dabs(A(1, 2)) + dabs(A(1, 3)) + dabs(A(2, 3))
@@ -52,94 +55,9 @@ module scherzinger
                 return
             endif
 
-            ! store initial diagonal values
-            D(1) = A(1, 1)
-            D(2) = A(2, 2)
-            D(3) = A(3, 3)
-
-            ! deviatoric matrix:
-            tr = trace(A)
-            tmp = f13 * tr
-            A(1, 1) = A(1, 1) - tmp
-            A(2, 2) = A(2, 2) - tmp
-            A(3, 3) = A(3, 3) - tmp
-
-            ! invariants j2 and j3:
-            AA = matmul(A, A)
-            j2 = f12 * trace(AA)
-            j3 = determinant(A)
-
-            ! angle:
-            alpha = f13 * acos(f12 * j3 * (three / j2) ** f32)
-
-            if (alpha > pi / 6.0d0) then
-                alpha = alpha + two * f13 * pi
-            endif
-
-            eta(1) = two * sqrt(f13 * j2) * cos(alpha)
-
-            r(:, 1) = (/ A(1, 1) - eta(1), A(2, 1),          A(3, 1)          /)
-            r(:, 2) = (/ A(1, 2),          A(2, 2) - eta(1), A(3, 2)          /)
-            r(:, 3) = (/ A(1, 3),          A(2, 3),          A(3, 3) - eta(1) /)
-
-            ! length of each r vector
-            rlen = norm2(r, dim=1)
-
-            i = maxloc(rlen, dim=1)
-
-            ! s1
-            if (i == 1) then
-                r(:, 1) = r(:, i) / rlen(i)
-            else if (i == 2) then
-                rlen = r(:, 2) / rlen(2)
-
-                r(:, 2) = r(:, 1)
-                r(:, 1) = rlen
-            else if (i == 3) then
-                rlen = r(:, 3) / rlen(3)
-
-                r(:, 3) = r(:, 1)
-                r(:, 1) = rlen
-
-            else
-                print *, "Error"
-                stop
-            endif
-
-            tmp = dot_product(r(:, 1), r(:, 2))
-            smp = dot_product(r(:, 1), r(:, 3))
-            r(:, 2) = r(:, 2) - tmp * r(:, 1)
-            r(:, 3) = r(:, 3) - smp * r(:, 1)
-
-            ! length of each r vector
-            rlen = norm2(r, dim=1)
-
-            i = maxloc(rlen(2:3), dim=1)
-
-            ! s2
-            r(:, 2) = r(:, i+1) / rlen(i+1)
+            call scherzinger_eigenvalues(A, D)
 
             V(:, 1) = cross(r(:, 1), r(:, 2))
-
-            rlen = matmul(A, r(:, 1))
-            s1As1 = dot_product(r(:, 1), rlen)
-            s2As1 = dot_product(r(:, 2), rlen)
-
-            rlen = matmul(A, r(:, 2))
-            s1As2 = dot_product(r(:, 1), rlen)
-            s2As2 = dot_product(r(:, 2), rlen)
-
-            tmp = s1As1 - s2As2
-            smp = s1As1 + s2As2
-
-            eta(2) = f12 * smp                                                    &
-                   - f12 * signum(tmp) * sqrt(tmp ** 2 + four * s1As2 * s2As1)
-
-            eta(3) = smp - eta(2)
-
-            A(1, 1) = D(1) - eta(2)
-            A(2, 2) = D(2) - eta(2)
-            A(3, 3) = D(3) - eta(2)
 
             ! u1 and u2
             rlen = matmul(A, r(:, 1))
@@ -154,10 +72,8 @@ module scherzinger
             V(:, 3) = r(:, i) / rlen(i)
 
 
-            V(:, 2) = cross(V(:, 3), W(:, 1))
-            V(:, 3) = cross(V(:, 1), W(:, 2))
-
-            D = eta + f13 * tr
+            V(:, 2) = cross(V(:, 3), V(:, 1))
+            V(:, 3) = cross(V(:, 1), V(:, 2))
 
 
             call sort_descending(D, V)
@@ -169,9 +85,9 @@ module scherzinger
         ! @param[inout] D eigenvalues
         ! @param[inout] V eigenvector matrix
         pure subroutine sort_descending(D, V)
-            double precision, intent(inout) :: D(n)
-            double precision, intent(inout) :: V(n, n)
-            double precision                :: teval, tevec(n)
+            double precision, intent(inout) :: D(3)
+            double precision, intent(inout) :: V(3, 3)
+            double precision                :: teval, tevec(3)
 
             if (D(2) > D(1)) then
                 teval = D(1)
@@ -209,38 +125,104 @@ module scherzinger
         ! entries will be storing the eigenvalues
         ! @param[inout] A real symmetric 3x3 matrix
         ! @param[out] D eigenvalues in descending order
-        pure subroutine scherzinger_eigenvalues(A, D)
-            double precision, intent(inout) :: A(n, n)
-            double precision, intent(out)   :: D(n)
-            double precision                :: B(n), Z(n)
-            integer                         :: i, j
-            double precision                :: sm
+        subroutine scherzinger_eigenvalues(A, D)
+            double precision, intent(inout) :: A(3, 3)
+            double precision, intent(out)   :: D(3)
+            double precision                :: AA(3, 3)
+            double precision                :: tr, j2, j3, alpha, eta(3)
+            double precision                :: tmp, smp
+            double precision                :: s1As1, s1As2, s2As1, s2As2, rlen(3)
+            integer                         :: i
 
-            ! initialise
-            do j = 1, n
-                D(j) = A(j, j)
-                B(j) = D(j)
-                Z(j) = zero
-            enddo
+            ! store initial diagonal values
+            D(1) = A(1, 1)
+            D(2) = A(2, 2)
+            D(3) = A(3, 3)
 
-            ! sum of off-diagonal entries
-            ! sm should convergence to zero
-            sm = dabs(A(1, 2)) + dabs(A(1, 3)) + dabs(A(2, 3))
+            ! deviatoric matrix:
+            tr = trace(A)
+            tmp = f13 * tr
+            A(1, 1) = A(1, 1) - tmp
+            A(2, 2) = A(2, 2) - tmp
+            A(3, 3) = A(3, 3) - tmp
 
-            do while (sm > atol)
+            ! invariants j2 and j3:
+            AA = matmul(A, A)
+            j2 = f12 * trace(AA)
+            j3 = determinant(A)
 
-                do i = 1, n-1
-                    do j = i+1, n
-                        call apply_rotation(A, D, Z, i, j)
-                    enddo
-                enddo
+            ! angle:
+            alpha = f13 * dacos(f12 * j3 * (three / j2) ** f32)
 
-                B = B + Z
-                D = B
-                Z = zero
-                ! update sum of off-diagonals
-                sm = dabs(A(1, 2)) + dabs(A(1, 3)) + dabs(A(2, 3))
-            enddo
+            if (alpha > fpi6) then
+                alpha = alpha + two * f13 * pi
+            endif
+
+            eta(1) = two * dsqrt(f13 * j2) * dcos(alpha)
+
+            r(:, 1) = (/ A(1, 1) - eta(1), A(2, 1),          A(3, 1)          /)
+            r(:, 2) = (/ A(1, 2),          A(2, 2) - eta(1), A(3, 2)          /)
+            r(:, 3) = (/ A(1, 3),          A(2, 3),          A(3, 3) - eta(1) /)
+
+            ! length of each r vector
+            rlen = norm2(r, dim=1)
+
+            i = maxloc(rlen, dim=1)
+
+            ! s1
+            if (i == 1) then
+                r(:, 1) = r(:, i) / rlen(i)
+            else if (i == 2) then
+                rlen = r(:, 2) / rlen(2)
+
+                r(:, 2) = r(:, 1)
+                r(:, 1) = rlen
+            else
+                ! i == 3
+                rlen = r(:, 3) / rlen(3)
+
+                r(:, 3) = r(:, 1)
+                r(:, 1) = rlen
+            endif
+
+            tmp = dot_product(r(:, 1), r(:, 2))
+            smp = dot_product(r(:, 1), r(:, 3))
+            r(:, 2) = r(:, 2) - tmp * r(:, 1)
+            r(:, 3) = r(:, 3) - smp * r(:, 1)
+
+            ! length of each r vector
+            rlen = norm2(r, dim=1)
+
+            i = maxloc(rlen(2:3), dim=1)
+
+            ! s2
+            r(:, 2) = r(:, i+1) / rlen(i+1)
+
+!             V(:, 1) = cross(r(:, 1), r(:, 2))
+
+            rlen = matmul(A, r(:, 1))
+            s1As1 = dot_product(r(:, 1), rlen)
+            s2As1 = dot_product(r(:, 2), rlen)
+
+            rlen = matmul(A, r(:, 2))
+            s1As2 = dot_product(r(:, 1), rlen)
+            s2As2 = dot_product(r(:, 2), rlen)
+
+            tmp = s1As1 - s2As2
+            smp = s1As1 + s2As2
+
+            eta(2) = f12 * smp                                                    &
+                   - f12 * signum(tmp) * sqrt(tmp ** 2 + four * s1As2 * s2As1)
+
+            eta(3) = smp - eta(2)
+
+            A(1, 1) = D(1) - eta(2)
+            A(2, 2) = D(2) - eta(2)
+            A(3, 3) = D(3) - eta(2)
+
+
+
+            D = eta + f13 * tr
 
             call sort_eigenvalues(D)
 
@@ -249,7 +231,7 @@ module scherzinger
         ! Sort the eigenvalues in descending order.
         ! @param[inout] D eigenvalues
         pure subroutine sort_eigenvalues(D)
-            double precision, intent(inout) :: D(n)
+            double precision, intent(inout) :: D(3)
             double precision                :: teval
 
             if (D(2) > D(1)) then

--- a/src/utils/scherzinger.f90
+++ b/src/utils/scherzinger.f90
@@ -28,7 +28,7 @@ module scherzinger
         ! @param[inout] A real symmetric 3x3 matrix
         ! @param[out] D eigenvalues in descending order
         ! @param[out] V eigenvector matrix
-        pure subroutine scherzinger_diagonalise(A, D, V)
+        subroutine scherzinger_diagonalise(A, D, V)
             double precision, intent(inout) :: A(3, 3)
             double precision, intent(out)   :: D(3)
             double precision, intent(out)   :: V(3, 3)
@@ -115,18 +115,29 @@ module scherzinger
         ! @param[inout] A real symmetric 3x3 matrix
         ! @param[out] D eigenvalues in descending order
 
-        pure subroutine scherzinger_eigenvalues(A, D)
+        subroutine scherzinger_eigenvalues(A, D)
             double precision, intent(inout) :: A(3, 3)
             double precision, intent(out)   :: D(3)
             double precision                :: eta(3), r(3, 3)
+            double precision                :: tmp
 
-            call evaluate_eigenvalues(A, r, eta, D)
+            ! sum of off-diagonal entries
+            tmp = dabs(A(1, 2)) + dabs(A(1, 3)) + dabs(A(2, 3))
+
+            ! check if a diagonal matrix
+            if (tmp < atol) then
+                D(1) = A(1, 1)
+                D(2) = A(2, 2)
+                D(3) = A(3, 3)
+            else
+                call evaluate_eigenvalues(A, r, eta, D)
+            endif
 
             call sort_eigenvalues(D)
 
         end subroutine scherzinger_eigenvalues
 
-        pure subroutine evaluate_eigenvalues(A, r, eta, D)
+        subroutine evaluate_eigenvalues(A, r, eta, D)
             double precision, intent(inout) :: A(3, 3)
             double precision, intent(out)   :: eta(3), r(3, 3)
             double precision, intent(out)   :: D(3)
@@ -138,6 +149,7 @@ module scherzinger
 
             ! deviatoric matrix (eq 2):
             tr = trace(A)
+
             tmp = f13 * tr
             A(1, 1) = A(1, 1) - tmp
             A(2, 2) = A(2, 2) - tmp

--- a/src/utils/scherzinger.f90
+++ b/src/utils/scherzinger.f90
@@ -158,7 +158,14 @@ module scherzinger
             j3 = determinant(A)
 
             ! angle (solve eq 7 for alpha):
-            alpha = f13 * dacos(f12 * j3 * (three / j2) ** f32)
+            smp = f12 * j3 * (three / j2) ** f32
+            
+            ! make sure abs(smp) <= 1; round-off errors could cause
+            ! smp to be slightly larger/smaller
+            ! (e.g. cases like -1.0000000000000004 occurred)
+            smp = min(max(-one, smp), one)
+
+            alpha = f13 * dacos(smp)
 
             if (alpha > fpi6) then
                 alpha = alpha + f23 * pi

--- a/src/utils/scherzinger.f90
+++ b/src/utils/scherzinger.f90
@@ -75,6 +75,13 @@ module scherzinger
             V(:, 2) = cross(V(:, 3), V(:, 1))
             V(:, 3) = cross(V(:, 1), V(:, 2))
 
+            ! normalise vectors
+            rlen = norm2(V, dim=1)
+            V(:, 1) = V(:, 1) / rlen(1)
+            V(:, 2) = V(:, 2) / rlen(2)
+            V(:, 3) = V(:, 3) / rlen(3)
+
+
             if (D(2) > D(1)) then
                 tmp = D(1)
                 D(1) = D(2)

--- a/src/utils/scherzinger.f90
+++ b/src/utils/scherzinger.f90
@@ -50,7 +50,7 @@ module scherzinger
                 D(2) = A(2, 2)
                 D(3) = A(3, 3)
 
-                call sort_eigenvalues(D)
+                call sort_descending(D, V)
 
                 return
             endif
@@ -159,7 +159,7 @@ module scherzinger
 
             ! angle (solve eq 7 for alpha):
             smp = f12 * j3 * (three / j2) ** f32
-            
+
             ! make sure abs(smp) <= 1; round-off errors could cause
             ! smp to be slightly larger/smaller
             ! (e.g. cases like -1.0000000000000004 occurred)
@@ -259,5 +259,37 @@ module scherzinger
                 D(2) = teval
             endif
         end subroutine sort_eigenvalues
+
+        pure subroutine sort_descending(D, V)
+            double precision, intent(inout) :: D(3), V(3, 3)
+            double precision                :: teval, tevec(3)
+
+            if (D(2) > D(1)) then
+                teval = D(1)
+                D(1) = D(2)
+                D(2) = teval
+                tevec = V(:, 1)
+                V(:, 1) = V(:, 2)
+                V(:, 2) = tevec
+            endif
+
+            if (D(3) > D(2)) then
+                teval = D(2)
+                D(2) = D(3)
+                D(3) = teval
+                tevec = V(:, 2)
+                V(:, 2) = V(:, 3)
+                V(:, 3) = tevec
+            endif
+
+            if (D(2) > D(1)) then
+                teval = D(1)
+                D(1) = D(2)
+                D(2) = teval
+                tevec = V(:, 1)
+                V(:, 1) = V(:, 2)
+                V(:, 2) = tevec
+            endif
+        end subroutine sort_descending
 
 end module scherzinger

--- a/unit-tests/3d/Makefile.am
+++ b/unit-tests/3d/Makefile.am
@@ -28,6 +28,10 @@ unittests_PROGRAMS = 				\
 	test_jacobi_2				\
 	test_jacobi_3				\
 	test_jacobi_4				\
+	test_scherzinger_1			\
+	test_scherzinger_2			\
+	test_scherzinger_3			\
+	test_scherzinger_4			\
 	test_ellipsoid_split 			\
 	test_ellipsoid_split_merge		\
 	test_parcel_init_3d			\
@@ -72,6 +76,18 @@ test_jacobi_3_LDADD = libcombi.la
 
 test_jacobi_4_SOURCES = test_jacobi_4.f90
 test_jacobi_4_LDADD = libcombi.la
+
+test_scherzinger_1_SOURCES = test_scherzinger_1.f90
+test_scherzinger_1_LDADD = libcombi.la
+
+test_scherzinger_2_SOURCES = test_scherzinger_2.f90
+test_scherzinger_2_LDADD = libcombi.la
+
+test_scherzinger_3_SOURCES = test_scherzinger_3.f90
+test_scherzinger_3_LDADD = libcombi.la
+
+test_scherzinger_4_SOURCES = test_scherzinger_4.f90
+test_scherzinger_4_LDADD = libcombi.la
 
 test_ellipsoid_split_SOURCES = test_ellipsoid_split.f90
 test_ellipsoid_split_LDADD = libcombi.la

--- a/unit-tests/3d/test_diffz4.f90
+++ b/unit-tests/3d/test_diffz4.f90
@@ -60,7 +60,7 @@ program test_diffz2
 
     error = max(error, maxval(dabs(dp - ref_sol)))
 
-    call print_result_dp('Test diffz', error, atol=4.0e-2)
+    call print_result_dp('Test diffz', error, atol=5.0e-2)
 
     deallocate(fp)
     deallocate(dp)

--- a/unit-tests/3d/test_diffz5.f90
+++ b/unit-tests/3d/test_diffz5.f90
@@ -59,7 +59,7 @@ program test_diffz2
 
     error = max(error, maxval(dabs(dp - ref_sol)))
 
-    call print_result_dp('Test diffz', error, atol=2.0e-1)
+    call print_result_dp('Test diffz', error, atol=0.25d0)
 
     deallocate(fp)
     deallocate(dp)

--- a/unit-tests/3d/test_ellipsoid_reflection.f90
+++ b/unit-tests/3d/test_ellipsoid_reflection.f90
@@ -115,7 +115,7 @@ program test_ellipsoid_reflection
         close(81)
     endif
 
-    call print_result_dp('Test ellipsoid reflection', error, atol=3.0e-13)
+    call print_result_dp('Test ellipsoid reflection', error, atol=1.0e-14)
 
     call parcel_dealloc
 

--- a/unit-tests/3d/test_ellipsoid_split.f90
+++ b/unit-tests/3d/test_ellipsoid_split.f90
@@ -10,7 +10,8 @@ program test_ellipsoid_split
     use parcel_container
     use parcel_ellipsoid, only : get_B33
     use parcel_split_mod, only : parcel_split, split_timer
-    use parameters, only : update_parameters, nx, ny, nz, extent, lower, set_vmax
+    use parameters, only : update_parameters, nx, ny, nz, extent, lower, set_amax
+    use options, only : parcel
     use timer
     implicit none
 
@@ -27,7 +28,7 @@ program test_ellipsoid_split
     lower = (/-five, -five, -five/)
     call update_parameters
 
-    call set_vmax(one)
+    parcel%lambda_max = four
 
     call register_timer('parcel split', split_timer)
     call register_timer('parcel container resize', resize_timer)
@@ -40,6 +41,8 @@ program test_ellipsoid_split
     a2 = ab * lam
     b2 = ab / lam
     c2 = (abc / ab) ** 2
+
+    call set_amax(f12 * a2)
 
     error = zero
 
@@ -55,7 +58,7 @@ program test_ellipsoid_split
             call setup_parcels
 
             ! numerical split
-            call parcel_split(parcels, threshold=four)
+            call parcel_split
 
             call check_result
         enddo

--- a/unit-tests/3d/test_ellipsoid_split.f90
+++ b/unit-tests/3d/test_ellipsoid_split.f90
@@ -30,6 +30,7 @@ program test_ellipsoid_split
     call set_vmax(one)
 
     call register_timer('parcel split', split_timer)
+    call register_timer('parcel container resize', resize_timer)
 
     call parcel_alloc(2)
 

--- a/unit-tests/3d/test_ellipsoid_split_merge.f90
+++ b/unit-tests/3d/test_ellipsoid_split_merge.f90
@@ -13,7 +13,8 @@ program test_ellipsoid_split_merge
     use parcel_merge, only : merge_parcels, merge_timer
     use parcel_nearest
     use parcel_split_mod, only : parcel_split, split_timer
-    use parameters, only : update_parameters, nx, ny, nz, extent, lower, set_vmax, set_vmin, vmin
+    use parameters, only : update_parameters, nx, ny, nz, extent, lower, set_amax, set_vmin, vmin
+    use options, only : parcel
     use timer
     implicit none
 
@@ -30,6 +31,8 @@ program test_ellipsoid_split_merge
     lower = (/-five, -five, -five/)
     call update_parameters
 
+    parcel%lambda_max = four
+
 
     abc = one
     ab = f34
@@ -42,7 +45,7 @@ program test_ellipsoid_split_merge
     call set_vmin(four / three * abc * pi)
 
     ! set vmax to half the initial volume
-    call set_vmax(f12 * vmin)
+    call set_amax(f12 * a2)
 
     call register_timer('parcel split', split_timer)
     call register_timer('parcel merge', merge_timer)
@@ -66,7 +69,7 @@ program test_ellipsoid_split_merge
             call setup_parcels
 
             ! numerical split
-            call parcel_split(parcels, threshold=four)
+            call parcel_split
 
             ! make sure we split
             error = max(error, abs(dble(2 - n_parcels)))

--- a/unit-tests/3d/test_ellipsoid_split_merge.f90
+++ b/unit-tests/3d/test_ellipsoid_split_merge.f90
@@ -13,7 +13,7 @@ program test_ellipsoid_split_merge
     use parcel_merge, only : merge_parcels, merge_timer
     use parcel_nearest
     use parcel_split_mod, only : parcel_split, split_timer
-    use parameters, only : update_parameters, nx, ny, nz, extent, lower, set_amax, set_vmin, vmin
+    use parameters, only : update_parameters, nx, ny, nz, extent, lower, set_amax, set_vmin
     use options, only : parcel
     use timer
     implicit none

--- a/unit-tests/3d/test_grid2par.f90
+++ b/unit-tests/3d/test_grid2par.f90
@@ -17,7 +17,6 @@ program test_trilinear
     double precision              :: error
     integer                       :: ix, iy, iz, i, j, k, l, n_per_dim
     double precision              :: im, corner(3)
-    double precision, allocatable :: vel(:, :), vortend(:, :), vgrad(:, :)
 
     nx = 32
     ny = 32
@@ -35,11 +34,6 @@ program test_trilinear
 
     n_parcels = n_per_dim ** 3 * nx *ny *nz
     call parcel_alloc(n_parcels)
-
-    allocate(vel(3, n_parcels))
-    allocate(vortend(3, n_parcels))
-    allocate(vgrad(5, n_parcels))
-
 
     im = one / dble(n_per_dim)
 
@@ -84,22 +78,17 @@ program test_trilinear
         velgradg(:, :, :, l) = dble(l)
     enddo
 
-    ! we cannot check vortend since parcels%vorticity is used in grid2par
-    call grid2par(vel, vortend, vgrad)
+    call grid2par
 
     error = zero
 
     do l = 1, 3
-        error = max(error, maxval(dabs(vel(l, 1:n_parcels) - dble(l))))
+        error = max(error, maxval(dabs(parcels%delta_pos(l, 1:n_parcels) - dble(l))))
     enddo
 
     do l = 1, 5
-        error = max(error, maxval(dabs(vgrad(l, 1:n_parcels) - dble(l))))
+        error = max(error, maxval(dabs(parcels%strain(l, 1:n_parcels) - dble(l))))
     enddo
     call print_result_dp('Test grid2par', error, atol=dble(1.0e-14))
-
-    deallocate(vel)
-    deallocate(vortend)
-    deallocate(vgrad)
 
 end program test_trilinear

--- a/unit-tests/3d/test_scherzinger_1.f90
+++ b/unit-tests/3d/test_scherzinger_1.f90
@@ -1,0 +1,132 @@
+! =============================================================================
+!               Test Scherzinger and Dohrmann diagonalisation
+!
+!               This unit test checks the eigenvalue solver.
+! =============================================================================
+program test_scherzinger_1
+    use unit_test
+    use constants, only : zero
+    use scherzinger
+    implicit none
+
+    double precision     :: error
+    integer              :: n, k, sk
+    logical              :: valid
+    double precision     :: V(3, 3)
+    double precision     :: B(3, 3), D(3)
+    double precision     :: Q(3, 3), EV(3) ! reference
+    integer, allocatable :: seed(:)
+
+    call random_seed(size=sk)
+    allocate(seed(1:sk))
+    seed(:) = 42
+    call random_seed(put=seed)
+
+
+    error = zero
+
+    n = 1
+    do while (n <= 100000)
+
+        call create_symmetric_matrix
+
+        if (valid) then
+            n = n + 1
+
+            call scherzinger_diagonalise(B, D, V)
+
+            ! check eigenvalues
+            error = max(error, dabs(EV(1) - D(1)) &
+                             + dabs(EV(2) - D(2)) &
+                             + dabs(EV(3) - D(3)))
+
+
+            ! check eigenvectors
+            do k = 1, 3
+                if (Q(1, k) / V(1, k) < zero) then
+                    ! opposite sign
+                    Q(:, k) = - Q(:, k)
+                endif
+                error = max(error, sum(dabs(Q(:, k) - V(:, k))))
+            enddo
+        endif
+    enddo
+
+    call print_result_dp('Test Scherzinger and Dohrmann 1', error, atol=dble(1.0e-9))
+
+    contains
+
+        subroutine create_symmetric_matrix
+            integer          :: i, j
+            double precision :: rndm(3, 3), val
+            double precision :: tmp
+
+            ! random eigenvalue
+            do j = 1, 3
+                call random_number(tmp)
+                EV(j) = 2.0d0 * tmp
+            enddo
+
+            ! sort
+            if (EV(1) < EV(2)) then
+                tmp = EV(1)
+                EV(1) = EV(2)
+                EV(2) = tmp
+            endif
+
+            if (EV(2) < EV(3)) then
+                tmp = EV(2)
+                EV(2) = EV(3)
+                EV(3) = tmp
+            endif
+
+            if (EV(1) < EV(2)) then
+                tmp = EV(1)
+                EV(1) = EV(2)
+                EV(2) = tmp
+            endif
+
+
+            ! Create orthogonal vectors using Gram-Schmidt orthogonalization
+            ! (https://de.wikipedia.org/wiki/Gram-Schmidtsches_Orthogonalisierungsverfahren)
+            do i = 1, 3
+                do j = 1, 3
+                    call random_number(val)
+                    rndm(i, j) = 10.0d0 * val
+                enddo
+            enddo
+
+            Q = 0.0d0
+
+            do j = 1, 3
+                Q(:, j) = rndm(:, j)
+                do i = 1, j - 1
+                    Q(:, j) = Q(:, j) &
+                            - Q(:, i) * dot_product(Q(:, i), rndm(:, j)) &
+                                      / dot_product(Q(:, i), Q(:, i))
+                enddo
+                Q(:, j) = Q(:, j) / norm2(Q(:, j))
+            enddo
+
+            ! Check orthogonalization error:
+            val = dabs(dot_product(Q(:, 1), Q(:, 2))) &
+                + dabs(dot_product(Q(:, 1), Q(:, 3))) &
+                + dabs(dot_product(Q(:, 2), Q(:, 3)))
+
+            valid = (val < 1.0e-13)
+            if (.not. valid) then
+                return
+            endif
+
+            ! Create symmetric B matrix
+            B = 0.0d0
+            do i = 1, 3
+                do j = 1, 3
+                    do k = 1, 3
+                        B(i, j) = B(i, j) + Q(i, k) * EV(k) * Q(j, k)
+                    enddo
+                enddo
+            enddo
+        end subroutine create_symmetric_matrix
+
+end program test_scherzinger_1

--- a/unit-tests/3d/test_scherzinger_2.f90
+++ b/unit-tests/3d/test_scherzinger_2.f90
@@ -1,0 +1,121 @@
+! =============================================================================
+!               Test Scherzinger and Dohrmann diagonalisation
+!
+!       This unit test checks compares the Jacobi diagonalisation with
+!       NumPy (numpy.linalg.eigh) (version 1.20.2)
+! =============================================================================
+program test_scherzinger_2
+    use unit_test
+    use constants, only : zero
+    use scherzinger
+    implicit none
+
+    double precision     :: error
+    integer              :: n, k, num
+    double precision     :: V(3, 3)
+    double precision     :: B(3, 3), D(3)
+    double precision     :: Q(3, 3), EV(3) ! reference
+
+    error = zero
+
+    call fopen
+
+    do n = 1, num
+
+        call read_next_line
+
+        call scherzinger_diagonalise(B, D, V)
+
+        ! check eigenvalues
+        error = max(error, dabs(EV(1) - D(1)) &
+                         + dabs(EV(2) - D(2)) &
+                         + dabs(EV(3) - D(3)))
+
+
+        ! check eigenvectors
+        do k = 1, 3
+            if (Q(1, k) / V(1, k) < zero) then
+                ! opposite sign
+                Q(:, k) = - Q(:, k)
+            endif
+            error = max(error, sum(dabs(Q(:, k) - V(:, k))))
+        enddo
+    enddo
+
+    call fclose
+
+    call print_result_dp('Test Scherzinger and Dohrmann 2', error, atol=dble(1.0e-12))
+
+    contains
+
+        subroutine fopen
+            call open_file('../share/B.asc', 1234)
+            read(1234, *) num
+
+            call open_file('../share/V.asc', 1235)
+            read(1235, *) n
+
+            if (num .ne. n) then
+                ! we do not perform this test
+                stop
+            endif
+
+            call open_file('../share/D.asc', 1236)
+            read(1236, *) n
+
+            if (num .ne. n) then
+                ! we do not perform this test
+                stop
+            endif
+        end subroutine fopen
+
+        subroutine open_file(fname, unit)
+            character(*), intent(in) :: fname
+            integer,      intent(in) :: unit
+            logical                  :: exists = .false.
+
+            inquire(file=fname, exist=exists)
+            if (.not. exists) then
+                call fclose
+                ! we do not perform this test
+                stop
+            endif
+            open(unit=unit, file=fname)
+        end subroutine open_file
+
+        subroutine fclose
+            integer :: unit
+            ! 20 October 2021
+            ! https://stackoverflow.com/questions/31941681/check-whether-file-has-been-opened-already
+
+            inquire(file='../share/B.asc', number=unit)
+            if (unit == 1234) then
+                close(1234)
+            endif
+
+            inquire(file='../share/V.asc', number=unit)
+            if (unit == 1235) then
+                close(1235)
+            endif
+
+            inquire(file='../share/D.asc', number=unit)
+            if (unit == 1236) then
+                close(1236)
+            endif
+        end subroutine fclose
+
+        subroutine read_next_line
+            ! B matrix
+            read(1234, *) B(1, 1), B(1, 2), B(1, 3), B(2, 2), B(2, 3), B(3, 3)
+            B(2, 1) = B(1, 2)
+            B(3, 1) = B(1, 3)
+            B(3, 2) = B(2, 3)
+
+            ! eigenvectors
+            read(1235, *) Q(:, 1), Q(:, 2), Q(:, 3)
+
+            ! eigenvalues
+            read(1236, *) EV(1), EV(2), EV(3)
+        end subroutine read_next_line
+
+end program test_scherzinger_2

--- a/unit-tests/3d/test_scherzinger_3.f90
+++ b/unit-tests/3d/test_scherzinger_3.f90
@@ -1,0 +1,112 @@
+! =============================================================================
+!                   Test Scherzinger and Dohrmann diagonalisation
+!
+!               This unit test checks the eigenvalue solver for
+!               spherical parcels. In the spherical case, the eigenvectors
+!               can point in any direction (but they are orthogonal to each
+!               other)
+! =============================================================================
+program test_scherzinger_3
+    use unit_test
+    use constants, only : zero, ten
+    use scherzinger
+    implicit none
+
+    double precision     :: error
+    integer              :: n, k, sk
+    double precision     :: V(3, 3)
+    double precision     :: B(3, 3), D(3)
+    double precision     :: A(3, 3), eval ! reference
+    integer, allocatable :: seed(:)
+
+    call random_seed(size=sk)
+    allocate(seed(1:sk))
+    seed(:) = 42
+    call random_seed(put=seed)
+
+
+    error = zero
+
+    do n = 1, 10000
+
+        call create_symmetric_matrix
+
+        call scherzinger_diagonalise(B, D, V)
+
+        ! check eigenvalues
+        error = max(error, dabs(eval - D(1)) &
+                         + dabs(eval - D(2)) &
+                         + dabs(eval - D(3)))
+
+        ! check eigenvectors
+        B = matmul(matmul(transpose(V), B), V)
+
+        B = dabs(A - B)
+
+        error = max(error, sum(B))
+
+        ! check if orthogonal
+        error = max(error, dabs(dot_product(V(:, 1), V(:, 2))))
+        error = max(error, dabs(dot_product(V(:, 1), V(:, 3))))
+        error = max(error, dabs(dot_product(V(:, 2), V(:, 3))))
+    enddo
+
+    call print_result_dp('Test Scherzinger and Dohrmann 3', error, atol=dble(1.0e-11))
+
+    contains
+
+        subroutine create_symmetric_matrix
+            integer          :: i, j
+            double precision :: rndm(3, 3), val
+            logical          :: valid
+            double precision :: Q(3, 3)
+
+            valid = .false.
+
+            do while (.not. valid)
+                call random_number(eval)
+                eval = 10 * eval
+
+                ! Create orthogonal vectors using Gram-Schmidt orthogonalization
+                ! (https://de.wikipedia.org/wiki/Gram-Schmidtsches_Orthogonalisierungsverfahren)
+                do i = 1, 3
+                    do j = 1, 3
+                        call random_number(val)
+                        rndm(i, j) = 10.0d0 * val
+                    enddo
+                enddo
+
+                Q = 0.0d0
+
+                do j = 1, 3
+                    Q(:, j) = rndm(:, j)
+                    do i = 1, j - 1
+                        Q(:, j) = Q(:, j) &
+                                - Q(:, i) * dot_product(Q(:, i), rndm(:, j)) &
+                                        / dot_product(Q(:, i), Q(:, i))
+                    enddo
+                    Q(:, j) = Q(:, j) / norm2(Q(:, j))
+                enddo
+
+                ! Check orthogonalization error:
+                val = dabs(dot_product(Q(:, 1), Q(:, 2))) &
+                    + dabs(dot_product(Q(:, 1), Q(:, 3))) &
+                    + dabs(dot_product(Q(:, 2), Q(:, 3)))
+
+                valid = (val < 1.0e-13)
+            enddo
+
+            ! Create symmetric B matrix
+            B = zero
+            do i = 1, 3
+                do j = 1, 3
+                    do k = 1, 3
+                        B(i, j) = B(i, j) + Q(i, k) * eval * Q(j, k)
+                    enddo
+                enddo
+            enddo
+
+            A = B
+        end subroutine create_symmetric_matrix
+
+end program test_scherzinger_3

--- a/unit-tests/3d/test_scherzinger_4.f90
+++ b/unit-tests/3d/test_scherzinger_4.f90
@@ -1,0 +1,44 @@
+! =============================================================================
+!                Test Scherzinger and Dohrmann diagonalisation
+!
+!               This unit test checks the eigenvalue solver for
+!               for a matrix of the form
+!                   /0  0  1\
+!                   |0  0  0|
+!                   \1  0  0/
+!               The eigenvalues of above matrix are +1, 0 and -1 the
+!               corresponding (normalised) eigenvectors:
+!                   v1 = ( 1/sqrt(2),  0,  1/sqrt(2))
+!                   v2 = ( 0,          1,  0)
+!                   v3 = (-1/sqrt(2),  0,  1/sqrt(2))
+! =============================================================================
+program test_scherzinger_4
+    use unit_test
+    use constants, only : zero, one, two
+    use scherzinger
+    implicit none
+
+    double precision     :: error, V(3, 3), B(3, 3), D(3)
+    double precision, parameter :: fsqrt2 = one / dsqrt(two)
+    error = zero
+
+    B = zero
+    B(1, 3) = one
+    B(3, 1) = one
+
+    call scherzinger_diagonalise(B, D, V)
+
+    ! check eigenvalues
+    error = max(error, dabs( one - D(1)) &
+                     + dabs(zero - D(2)) &
+                     + dabs(-one - D(3)))
+
+
+    error = max(error,                                                  &
+                maxval(dabs((/fsqrt2, zero, fsqrt2 /) - V(:, 1))),      &
+                maxval(dabs((/zero,   -one,   zero /) - V(:, 2))),      &
+                maxval(dabs((/fsqrt2, zero, -fsqrt2/) - V(:, 3))))
+
+    call print_result_dp('Test Scherzinger and Dohrmann 4', error, atol=dble(1.0e-15))
+
+end program test_scherzinger_4

--- a/unit-tests/3d/test_vor2vel.f90
+++ b/unit-tests/3d/test_vor2vel.f90
@@ -16,7 +16,7 @@ program test_vor2vel_2
     use constants, only : zero, one, two, four, pi, twopi, f12
     use parameters, only : lower, update_parameters, dx, nx, ny, nz, extent
     use fields, only : vortg, velog, field_alloc
-    use inversion_utils, only : init_fft, fftxyp2s
+    use inversion_utils, only : init_inversion
     use inversion_mod, only : vor2vel, vor2vel_timer
     use timer
     implicit none
@@ -69,13 +69,13 @@ program test_vor2vel_2
         enddo
     enddo
 
-    call init_fft
+    call init_inversion
 
     call vor2vel
 
     error = maxval(dabs(velog_ref(0:nz, :, :, :) - velog(0:nz, :, :, :)))
 
-    call print_result_dp('Test inversion (vorticity)', error, atol=2.0e-3)
+    call print_result_dp('Test inversion (vorticity)', error, atol=1.0e-14)
 
     deallocate(velog_ref)
 


### PR DESCRIPTION
This PR applies all code optimizations to the serial version of EPIC, these are
* option to run RK3 (see #487)
* Scherzinger eigenvalue/-vector solver (see #488 and #495)
* amax instead of vmax (see #489)
* container resizing (see #493)