### PR TITLE
Fix unit-tests -- register missing timer and fix function call

### DIFF
--- a/unit-tests/3d/test_mpi_diffz2.f90
+++ b/unit-tests/3d/test_mpi_diffz2.f90
@@ -1,18 +1,18 @@
 ! =============================================================================
 !                       Test subroutine diffz
 !
-!  This unit test checks the subroutine diffz and central_diffz using the
-!  function:
+!  This unit test checks the subroutine diffz and central_diffz_semi_spectral
+!  using the function:
 !               cos(x) cos(y) cos(z)
 !  in a domain of width 2 * pi in x and y, and of height pi (0 < z < pi)
-!  The subroutine diffz and central_diffz should return
+!  The subroutine diffz and central_diffz_semi_spectral should return
 !               - cos(x) cos(y) sin(z)
 ! =============================================================================
 program test_mpi_diffz2
     use unit_test
     use constants, only : zero, one, two, pi, twopi, f12
     use parameters, only : lower, update_parameters, dx, nx, ny, nz, extent
-    use inversion_mod, only : central_diffz, diffz, init_inversion, fftxyp2s, fftxys2p &
+    use inversion_mod, only : central_diffz_semi_spectral, diffz, init_inversion, fftxyp2s, fftxys2p &
                             , field_decompose_physical, field_combine_physical
     use mpi_environment
     use mpi_layout
@@ -65,7 +65,7 @@ program test_mpi_diffz2
 
     dp = fp
     call fftxyp2s(dp, fs)
-    call central_diffz(fs, ds)
+    call central_diffz_semi_spectral(fs, ds)
     call fftxys2p(ds, dp)
 
     error = maxval(dabs(dp(:, box%lo(2):box%hi(2), box%lo(1):box%hi(1)) &

--- a/unit-tests/3d/test_mpi_diffz3.f90
+++ b/unit-tests/3d/test_mpi_diffz3.f90
@@ -1,18 +1,18 @@
 ! =============================================================================
 !                       Test subroutine diffz
 !
-!  This unit test checks the subroutine diffz and central_diffz using the
-!  function:
+!  This unit test checks the subroutine diffz and central_diffz_semi_spectral
+!  using the function:
 !               z
 !  in a domain of width 2 * pi in x and y, and of height pi (-pi/2 < z < pi/2)
-!  The subroutine diffz and central_diffz should return
+!  The subroutine diffz and central_diffz_semi_spectral should return
 !               1
 ! =============================================================================
 program test_mpi_diffz3
     use unit_test
     use constants, only : zero, one, two, pi, twopi, f12
     use parameters, only : lower, update_parameters, dx, nx, ny, nz, extent
-    use inversion_mod, only : init_inversion, central_diffz, diffz &
+    use inversion_mod, only : init_inversion, central_diffz_semi_spectral, diffz &
                             , field_combine_physical, field_decompose_physical, fftxyp2s, fftxys2p
     use mpi_environment
     use mpi_layout
@@ -59,7 +59,7 @@ program test_mpi_diffz3
 
     dp = fp
     call fftxyp2s(dp, fs)
-    call central_diffz(fs, ds)
+    call central_diffz_semi_spectral(fs, ds)
     call fftxys2p(ds, dp)
 
     error = maxval(dabs(dp(:, box%lo(2):box%hi(2), box%lo(1):box%hi(1)) &

--- a/unit-tests/3d/test_mpi_diffz4.f90
+++ b/unit-tests/3d/test_mpi_diffz4.f90
@@ -1,18 +1,18 @@
 ! =============================================================================
 !                       Test subroutine diffz
 !
-!  This unit test checks the subroutine diffz and central_diffz using the
-!  function:
+!  This unit test checks the subroutine diffz and central_diffz_semi_spectral
+!  using the function:
 !               z^2
 !  in a domain of width 2 * pi in x and y, and of height pi (-pi/2 < z < pi/2)
-!  The subroutine diffz and central_diffz should return
+!  The subroutine diffz and central_diffz_semi_spectral should return
 !               2z
 ! =============================================================================
 program test_mpi_diffz4
     use unit_test
     use constants, only : zero, one, two, pi, twopi, f12
     use parameters, only : lower, update_parameters, dx, nx, ny, nz, extent
-    use inversion_mod, only : init_inversion, central_diffz, diffz &
+    use inversion_mod, only : init_inversion, central_diffz_semi_spectral, diffz &
                             , field_combine_physical, field_decompose_physical, fftxyp2s, fftxys2p
     use mpi_environment
     use mpi_layout
@@ -59,7 +59,7 @@ program test_mpi_diffz4
 
     dp = fp
     call fftxyp2s(dp, fs)
-    call central_diffz(fs, ds)
+    call central_diffz_semi_spectral(fs, ds)
     call fftxys2p(ds, dp)
 
     error = maxval(dabs(dp(:, box%lo(2):box%hi(2), box%lo(1):box%hi(1)) &

--- a/unit-tests/3d/test_mpi_diffz5.f90
+++ b/unit-tests/3d/test_mpi_diffz5.f90
@@ -1,18 +1,18 @@
 ! =============================================================================
 !                       Test subroutine diffz
 !
-!  This unit test checks the subroutine diffz and central_diffz using the
-!  function:
+!  This unit test checks the subroutine diffz and central_diffz_semi_spectral
+!  using the function:
 !               z^3
 !  in a domain of width 2 * pi in x and y, and of height pi (-pi/2 < z < pi/2)
-!  The subroutine diffz and central_diffz should return
+!  The subroutine diffz and central_diffz_semi_spectral should return
 !               3z^2
 ! =============================================================================
 program test_mpi_diffz5
     use unit_test
     use constants, only : zero, three, pi, twopi, f12
     use parameters, only : lower, update_parameters, dx, nx, ny, nz, extent
-    use inversion_mod, only : init_inversion, central_diffz, diffz &
+    use inversion_mod, only : init_inversion, central_diffz_semi_spectral, diffz &
                             , field_combine_physical, field_decompose_physical, fftxyp2s, fftxys2p
     use mpi_environment
     use mpi_layout
@@ -59,7 +59,7 @@ program test_mpi_diffz5
 
     dp = fp
     call fftxyp2s(dp, fs)
-    call central_diffz(fs, ds)
+    call central_diffz_semi_spectral(fs, ds)
     call fftxys2p(ds, dp)
 
     error = maxval(dabs(dp(:, box%lo(2):box%hi(2), box%lo(1):box%hi(1)) &

--- a/unit-tests/3d/test_mpi_gradient_correction_3d.f90
+++ b/unit-tests/3d/test_mpi_gradient_correction_3d.f90
@@ -15,7 +15,7 @@ program test_mpi_gradient_correction_3d
                                 , grad_corr_timer           &
                                 , vort_corr_timer           &
                                 , init_parcel_correction
-    use parcel_interpl, only : vol2grid
+    use parcel_interpl, only : vol2grid, halo_swap_timer
     use parcel_ellipsoid, only : get_abc
     use parcel_init, only : init_regular_positions
     use parameters, only : lower, extent, update_parameters, vcell, nx, ny, nz, dx
@@ -47,6 +47,7 @@ program test_mpi_gradient_correction_3d
 
     call register_timer('gradient correction', grad_corr_timer)
     call register_timer('vorticity correction', vort_corr_timer)
+    call register_timer('halo swap', halo_swap_timer)
 
     nx = 32
     ny = 32

--- a/unit-tests/3d/test_mpi_laplace_correction_3d.f90
+++ b/unit-tests/3d/test_mpi_laplace_correction_3d.f90
@@ -15,7 +15,7 @@ program test_mpi_laplace_correction_3d
                                 , lapl_corr_timer           &
                                 , vort_corr_timer           &
                                 , init_parcel_correction
-    use parcel_interpl, only : vol2grid
+    use parcel_interpl, only : vol2grid, halo_swap_timer
     use parcel_ellipsoid, only : get_abc
     use parcel_init, only : init_regular_positions
     use parameters, only : lower, extent, update_parameters, vcell, nx, ny, nz, dx
@@ -47,6 +47,7 @@ program test_mpi_laplace_correction_3d
 
     call register_timer('laplace correction', lapl_corr_timer)
     call register_timer('vorticity correction', vort_corr_timer)
+    call register_timer('halo swap', halo_swap_timer)
 
     nx = 32
     ny = 32

--- a/unit-tests/3d/test_mpi_parcel_correction_3d.f90
+++ b/unit-tests/3d/test_mpi_parcel_correction_3d.f90
@@ -17,7 +17,7 @@ program test_parcel_correction_3d
                                 , grad_corr_timer           &
                                 , vort_corr_timer           &
                                 , init_parcel_correction
-    use parcel_interpl, only : vol2grid
+    use parcel_interpl, only : vol2grid, halo_swap_timer
     use parcel_ellipsoid, only : get_abc
     use parcel_init, only : init_regular_positions
     use parameters, only : lower, extent, update_parameters, vcell, nx, ny, nz, dx
@@ -50,6 +50,7 @@ program test_parcel_correction_3d
     call register_timer('laplace correction', lapl_corr_timer)
     call register_timer('gradient correction', grad_corr_timer)
     call register_timer('vorticity correction', vort_corr_timer)
+    call register_timer('halo swap', halo_swap_timer)
 
     nx = 32
     ny = 32

--- a/unit-tests/3d/test_mpi_parcel_init_3d.f90
+++ b/unit-tests/3d/test_mpi_parcel_init_3d.f90
@@ -11,7 +11,7 @@ program test_mpi_parcel_init_3d
     use constants, only : pi, zero, one, two, four, five, f12, f13, f23, f32
     use parcel_container
     use parcel_init, only : init_timer, parcel_default, init_parcels_from_grids
-    use parcel_interpl, only : par2grid, par2grid_timer
+    use parcel_interpl, only : par2grid, par2grid_timer, halo_swap_timer
     use parcel_ellipsoid, only : get_abc
     use fields, only : tbuoyg, field_default
     use field_ops, only : get_rms, get_abs_max
@@ -49,6 +49,7 @@ program test_mpi_parcel_init_3d
 
     call register_timer('parcel init', init_timer)
     call register_timer('par2grid', par2grid_timer)
+    call register_timer('halo swap', halo_swap_timer)
 
     call mpi_layout_init(lower, extent, nx, ny, nz)
 

--- a/unit-tests/3d/test_mpi_trilinear.f90
+++ b/unit-tests/3d/test_mpi_trilinear.f90
@@ -9,7 +9,7 @@ program test_mpi_trilinear
     use constants, only : pi, zero, one, f12, f23, f32
     use parcel_container
     use mpi_layout
-    use parcel_interpl, only : par2grid, par2grid_timer
+    use parcel_interpl, only : par2grid, par2grid_timer, halo_swap_timer
     use parcel_ellipsoid, only : get_abc
     use parameters, only : lower, update_parameters, vcell, dx, nx, ny, nz, ngrid
     use fields, only : volg, field_alloc
@@ -33,6 +33,7 @@ program test_mpi_trilinear
     extent =  (/0.4d0, 0.4d0, 0.4d0/)
 
     call register_timer('par2grid', par2grid_timer)
+    call register_timer('halo swap', halo_swap_timer)
 
     call mpi_layout_init(lower, extent, nx, ny, nz)
 


### PR DESCRIPTION
This PR
* registers the missing `halo_swap_timer` in some unit-tests.
* changes the function call as we now distinguish between spectral and physical space vertical derivatives (see #504).