### PR TITLE
Simplify parcel merge routine call

### DIFF
--- a/mpi-tests/test_merging_parcels.f90
+++ b/mpi-tests/test_merging_parcels.f90
@@ -3,7 +3,7 @@ program test_merging_parcels
     use parcel_container
     use options, only : parcel
     use parameters, only : update_parameters, lower, extent, nx, ny, nz, max_num_parcels
-    use parcel_merge
+    use parcel_merging
     use parcel_netcdf
     use mpi_communicator
     use mpi_layout
@@ -44,7 +44,7 @@ program test_merging_parcels
                        comm%world,      &
                        comm%err)
 
-    call merge_parcels(parcels)
+    call parcel_merge
 
     n_total_parcels = 0
     call MPI_Allreduce(n_parcels,       &

--- a/mpi-tests/test_parcel_merge_random.f90
+++ b/mpi-tests/test_parcel_merge_random.f90
@@ -9,7 +9,7 @@ program test_parcel_merge_random
     use fields, only : field_default
     use parcel_bc, only : apply_periodic_bc
     use parcel_interpl, only : par2grid
-    use parcel_merge, only : merge_parcels
+    use parcel_merging, only : parcel_merge
     use parcel_nearest
     use mpi_layout, only : box, mpi_layout_init
     use test_utils
@@ -105,7 +105,7 @@ program test_parcel_merge_random
         n_orig = n_parcels
 
         ! Merge parcels
-        call merge_parcels(parcels)
+        call parcel_merge(parcels)
 
         ! Interpolate parcel data to grid
         call par2grid

--- a/mpi-tests/test_parcel_merge_random.f90
+++ b/mpi-tests/test_parcel_merge_random.f90
@@ -105,7 +105,7 @@ program test_parcel_merge_random
         n_orig = n_parcels
 
         ! Merge parcels
-        call parcel_merge(parcels)
+        call parcel_merge
 
         ! Interpolate parcel data to grid
         call par2grid

--- a/mpi-tests/test_parcel_split_merge.f90
+++ b/mpi-tests/test_parcel_split_merge.f90
@@ -10,7 +10,7 @@ program test_parcel_spli_merge
     use parcel_bc, only : apply_periodic_bc, apply_reflective_bc
     use parcel_interpl, only : par2grid
     use parcel_split_mod, only : parcel_split
-    use parcel_merging, only : merge_parcels
+    use parcel_merging, only : parcel_merge
     use parcel_nearest
     use mpi_layout, only : mpi_layout_init
     use test_utils
@@ -100,7 +100,7 @@ program test_parcel_spli_merge
             print *, "Merge", n_merges, "of", n_total_parcels, "parcels."
         endif
 
-        call merge_parcels(parcels)
+        call parcel_merge
 
         do n = 1, n_parcels
             call random_number(rn)

--- a/mpi-tests/test_parcel_split_merge.f90
+++ b/mpi-tests/test_parcel_split_merge.f90
@@ -10,7 +10,7 @@ program test_parcel_spli_merge
     use parcel_bc, only : apply_periodic_bc, apply_reflective_bc
     use parcel_interpl, only : par2grid
     use parcel_split_mod, only : parcel_split
-    use parcel_merge, only : merge_parcels
+    use parcel_merging, only : merge_parcels
     use parcel_nearest
     use mpi_layout, only : mpi_layout_init
     use test_utils

--- a/mpi-tests/test_utils.f90
+++ b/mpi-tests/test_utils.f90
@@ -2,7 +2,7 @@ module test_utils
     use mpi_timer
     use parcel_container, only : resize_timer
     use parcel_split_mod, only : split_timer
-    use parcel_merge, only : merge_timer
+    use parcel_merging, only : merge_timer
     use parcel_nearest, only : merge_nearest_timer, merge_tree_resolve_timer
     use parcel_correction, only : lapl_corr_timer,        &
                                   grad_corr_timer,        &

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -7,7 +7,7 @@ program epic3d
     use parcel_container
     use parcel_bc
     use parcel_split_mod, only : parcel_split, split_timer
-    use parcel_merge, only : merge_parcels, merge_timer
+    use parcel_merging, only : parcel_merge, merge_timer
     use parcel_nearest, only : merge_nearest_timer      &
                              , merge_tree_resolve_timer &
                              , nearest_win_allocate     &
@@ -131,7 +131,7 @@ program epic3d
 
                 call ls_rk_step(t)
 
-                call merge_parcels(parcels)
+                call parcel_merge
 
                 call parcel_split
 

--- a/src/3d/parcels/parcel_diagnostics.f90
+++ b/src/3d/parcels/parcel_diagnostics.f90
@@ -7,7 +7,7 @@ module parcel_diagnostics
     use parcel_container, only : parcels, n_parcels, n_total_parcels
     use parcel_ellipsoid
     use parcel_split_mod, only : n_parcel_splits
-    use parcel_merge, only : n_parcel_merges
+    use parcel_merging, only : n_parcel_merges
     use omp_lib
     use physics, only : ape_calculation
     use ape_density, only : ape_den

--- a/src/3d/parcels/parcel_diagnostics_netcdf.f90
+++ b/src/3d/parcels/parcel_diagnostics_netcdf.f90
@@ -10,7 +10,7 @@ module parcel_diagnostics_netcdf
     use parcel_diagnostics
     use parameters, only : lower, extent, nx, ny, nz, write_zeta_boundary_flag
     use parcel_split_mod, only : n_parcel_splits
-    use parcel_merge, only : n_parcel_merges
+    use parcel_merging, only : n_parcel_merges
     use config, only : package_version, cf_version
     use mpi_timer, only : start_timer, stop_timer
     use options, only : write_netcdf_options

--- a/src/3d/parcels/parcel_merge.f90
+++ b/src/3d/parcels/parcel_merge.f90
@@ -2,15 +2,15 @@
 !                       Module to merge ellipsoids
 !           The module implements the geometric merge procedure.
 ! =============================================================================
-module parcel_merge
+module parcel_merging
     use parcel_nearest
     use constants, only : pi, zero, one, two, five, f13
-    use parcel_container, only : parcel_container_type                  &
-                               , n_parcels                              &
-                               , n_total_parcels                        &
-                               , parcel_replace                         &
-                               , get_delx_across_periodic               &
-                               , get_dely_across_periodic               &
+    use parcel_container, only : parcels                    &
+                               , n_parcels                  &
+                               , n_total_parcels            &
+                               , parcel_replace             &
+                               , get_delx_across_periodic   &
+                               , get_dely_across_periodic   &
                                , parcel_delete
     use parcel_ellipsoid, only : get_B33, get_abc
     use options, only : parcel, verbose
@@ -33,20 +33,17 @@ module parcel_merge
 
         ! Merge small parcels into neighbouring equal-sized parcels or bigger
         ! parcels which are close by.
-        ! @param[inout] parcels is the parcel container
-        subroutine merge_parcels(parcels)
-            type(parcel_container_type), intent(inout) :: parcels
-            integer, allocatable, dimension(:)         :: isma
-            integer, allocatable, dimension(:)         :: iclo
-            integer, allocatable, dimension(:)         :: inva
-            integer                                    :: n_merge ! number of merges
-            integer                                    :: n_invalid
+        subroutine parcel_merge
+            integer, allocatable, dimension(:) :: isma
+            integer, allocatable, dimension(:) :: iclo
+            integer, allocatable, dimension(:) :: inva
+            integer                            :: n_merge ! number of merges
+            integer                            :: n_invalid
 #ifdef ENABLE_VERBOSE
-            integer                                    :: orig_num
+            integer                            :: orig_num
 
             orig_num = n_total_parcels
 #endif
-
 
             ! find parcels to merge
             call find_nearest(isma, iclo, inva, n_merge, n_invalid)
@@ -57,7 +54,7 @@ module parcel_merge
 
             if (n_merge > 0) then
                 ! merge small parcels into other parcels
-                call geometric_merge(parcels, isma, iclo, n_merge)
+                call geometric_merge(isma, iclo, n_merge)
             endif
 
             if (n_merge + n_invalid > 0) then
@@ -87,32 +84,30 @@ module parcel_merge
 
             call stop_timer(merge_timer)
 
-        end subroutine merge_parcels
+        end subroutine parcel_merge
 
 
         ! Actual merge.
-        ! @param[inout] parcels is the parcel container
         ! @param[in] isma are the indices of the small parcels
         ! @param[in] iclo are the indices of the close parcels
         ! @param[in] n_merge is the array size of isma and iclo
         ! @param[out] Bm are the B matrix entries of the mergers
         ! @param[out] vm are the volumes of the mergers
-        subroutine do_group_merge(parcels, isma, iclo, n_merge, Bm, vm)
-            type(parcel_container_type), intent(inout) :: parcels
-            integer,                     intent(in)    :: isma(0:)
-            integer,                     intent(in)    :: iclo(:)
-            integer,                     intent(in)    :: n_merge
-            integer                                    :: m, ic, is, l, n
-            integer                                    :: loca(n_parcels)
-            double precision                           :: x0(n_merge), y0(n_merge)
-            double precision                           :: posm(3, n_merge)
-            double precision                           :: delx, vmerge, dely, delz, B33, mu
-            double precision                           :: buoym(n_merge), vortm(3, n_merge)
+        subroutine do_group_merge(isma, iclo, n_merge, Bm, vm)
+            integer,          intent(in)    :: isma(0:)
+            integer,          intent(in)    :: iclo(:)
+            integer,          intent(in)    :: n_merge
+            integer                         :: m, ic, is, l, n
+            integer                         :: loca(n_parcels)
+            double precision                :: x0(n_merge), y0(n_merge)
+            double precision                :: posm(3, n_merge)
+            double precision                :: delx, vmerge, dely, delz, B33, mu
+            double precision                :: buoym(n_merge), vortm(3, n_merge)
 #ifndef ENABLE_DRY_MODE
-            double precision                           :: hum(n_merge)
+            double precision                :: hum(n_merge)
 #endif
-            double precision,            intent(out)   :: Bm(6, n_merge) ! B11, B12, B13, B22, B23, B33
-            double precision,            intent(out)   :: vm(n_merge)
+            double precision, intent(out)   :: Bm(6, n_merge) ! B11, B12, B13, B22, B23, B33
+            double precision, intent(out)   :: vm(n_merge)
 
             loca = zero
 
@@ -283,18 +278,17 @@ module parcel_merge
         ! @param[in] isma are the indices of the small parcels
         ! @param[in] iclo are the indices of the close parcels
         ! @param[in] n_merge is the array size of isma and iclo
-        subroutine geometric_merge(parcels, isma, iclo, n_merge)
-            type(parcel_container_type), intent(inout) :: parcels
-            integer,                     intent(in)    :: isma(0:)
-            integer,                     intent(in)    :: iclo(:)
-            integer,                     intent(in)    :: n_merge
-            integer                                    :: m, ic, l
-            integer                                    :: loca(n_parcels)
-            double precision                           :: factor, detB
-            double precision                           :: B(6, n_merge), &
-                                                          V(n_merge)
+        subroutine geometric_merge(isma, iclo, n_merge)
+            integer,         intent(in) :: isma(0:)
+            integer,         intent(in) :: iclo(:)
+            integer,         intent(in) :: n_merge
+            integer                     :: m, ic, l
+            integer                     :: loca(n_parcels)
+            double precision            :: factor, detB
+            double precision            :: B(6, n_merge), &
+                                        V(n_merge)
 
-            call do_group_merge(parcels, isma, iclo, n_merge, B, V)
+            call do_group_merge(isma, iclo, n_merge, B, V)
 
             loca = zero
 
@@ -321,4 +315,4 @@ module parcel_merge
 
         end subroutine geometric_merge
 
-end module parcel_merge
+end module parcel_merging


### PR DESCRIPTION
Remove subroutine input argument. We do not need to pass the parcel container.