### PR TITLE
Add missing field statistics timer stop

### DIFF
--- a/src/3d/fields/field_diagnostics_netcdf.f90
+++ b/src/3d/fields/field_diagnostics_netcdf.f90
@@ -247,6 +247,7 @@ module field_diagnostics_netcdf
             call start_timer(field_stats_io_timer)
 
             if (world%rank /= world%root) then
+                call stop_timer(field_stats_io_timer)
                 return
             endif
 

--- a/src/3d/inversion/inversion_utils.f90
+++ b/src/3d/inversion/inversion_utils.f90
@@ -18,7 +18,7 @@ module inversion_utils
     private
 
     ! Ordering in physical space: z, y, x
-    ! Ordering in spectral space: z, x, y
+    ! Ordering in spectral space: z, y, x
 
     ! Tridiagonal arrays for the vertical vorticity component:
     double precision, allocatable :: etdv(:, :, :), htdv(:, :, :)


### PR DESCRIPTION
Only the root rank writes the field statistics. All other MPI ranks leave early, hence they must stop their timers.