### PR TITLE
Calculate squared buoyancy frequency only if not provided

### DIFF
--- a/src/3d/utils/utils.f90
+++ b/src/3d/utils/utils.f90
@@ -219,11 +219,7 @@ module utils
                 if (file_type == 'fields') then
                     call read_netcdf_fields(field_file, -1)
                     call init_parcels_from_grids
-#ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
-                   ! If not in restart mode, we could not read in the squared buoyancy frequency.
-                   ! We must calculate it.
-                   call calculate_basic_reference_state(nx, ny, nz, extent(3), tbuoyg)
-#endif
+
                    ! we must check if zeta must be kept zero
                    ! on a vertical boundary
                    call set_zeta_boundary_flag(vortg(:, :, :, I_Z))
@@ -233,6 +229,11 @@ module utils
                    call mpi_exit_on_error('Input file must be of type "fields" or "parcels".')
                endif
             endif
+
+#ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
+            ! Calculate the squared buoyancy frequency if not provided.
+            call calculate_basic_reference_state(nx, ny, nz, extent(3), tbuoyg)
+#endif
 
         end subroutine setup_fields_and_parcels
 

--- a/src/utils/physics.f90
+++ b/src/utils/physics.f90
@@ -387,6 +387,7 @@ module physics
                                world%err)
 
             bfsq = bfsq / (dble(nx * ny) * zext)
+            bf = dsqrt(bfsq)
 
             if (world%rank == world%root) then
                 print *, "Calculated squared buoyancy frequency:", bfsq

--- a/src/utils/physics.f90
+++ b/src/utils/physics.f90
@@ -270,7 +270,7 @@ module physics
 
 #ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
             if (l_bfsq) then
-                call write_netcdf_attribute(grp_ncid, 'squared_buoyancy_frequency', bf)
+                call write_netcdf_attribute(grp_ncid, 'squared_buoyancy_frequency', bfsq)
             endif
 #endif
 
@@ -301,7 +301,7 @@ module physics
 
 #ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
             if (l_bfsq) then
-                call print_physical_quantity('squared_buoyancy_frequency', bf, '1/s^2')
+                call print_physical_quantity('squared_buoyancy_frequency', bfsq, '1/s^2')
             endif
 #endif
             write(*, *) ''
@@ -366,6 +366,7 @@ module physics
                                                  box%hlo(2):box%hhi(2),  &
                                                  box%hlo(1):box%hhi(1))
 
+            ! We only calculate N^2 if it did not get provided as an input.
             if (l_bfsq) then
                 if (world%rank == world%root) then
                     print *, "Provided squared buoyancy frequency:", bfsq

--- a/src/utils/physics.f90
+++ b/src/utils/physics.f90
@@ -98,8 +98,12 @@ module physics
     character(len=11) :: ape_calculation = "sorting"
 
 #ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
-    ! buoyancy frequency, N^2
-    double precision, protected :: bfsq = 0.0d0
+    ! squared buoyancy frequency, N^2
+    double precision, protected :: bfsq = zero
+
+    ! buoyancy frequency, N
+    double precision, protected :: bf   = zero
+    logical                     :: l_bfreq = .false.
 #endif
 
     interface print_physical_quantity
@@ -113,6 +117,9 @@ module physics
                print_physical_quantity_double,      &
                print_physical_quantity_integer,     &
                print_physical_quantity_logical,     &
+#ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
+               l_bfreq,                             &
+#endif
                print_physical_quantity_character
 
     contains
@@ -197,7 +204,11 @@ module physics
                 call read_netcdf_attribute_default(grp_ncid, 'ape_calculation', ape_calculation)
 
 #ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
-                call read_netcdf_attribute_default(grp_ncid, 'squared_buoyancy_frequency', bfsq)
+                l_bfreq = has_attribute(grp_ncid, 'buoyancy_frequency')
+                if (l_bfreq) then
+                    call read_netcdf_attribute_default(grp_ncid, 'buoyancy_frequency', bf)
+                    bfsq = bf ** 2
+                endif
 #endif
 
                 l_peref = .false.
@@ -260,7 +271,9 @@ module physics
             call write_netcdf_attribute(grp_ncid, 'ape_calculation', ape_calculation)
 
 #ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
-            call write_netcdf_attribute(grp_ncid, 'squared_buoyancy_frequency', bfsq)
+            if (l_bfreq) then
+                call write_netcdf_attribute(grp_ncid, 'buoyancy_frequency', bf)
+            endif
 #endif
 
         end subroutine write_physical_quantities
@@ -289,9 +302,10 @@ module physics
             call print_physical_quantity('APE calculation', ape_calculation)
 
 #ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
-            call print_physical_quantity('squared_buoyancy_frequency', bfsq, '1/s^2')
+            if (l_bfreq) then
+                call print_physical_quantity('buoyancy_frequency', bf, '1/s')
+            endif
 #endif
-
             write(*, *) ''
         end subroutine print_physical_quantities
 
@@ -353,6 +367,13 @@ module physics
             double precision, intent(in) :: buoy(-1:nz+1,                &
                                                  box%hlo(2):box%hhi(2),  &
                                                  box%hlo(1):box%hhi(1))
+
+            if (l_bfreq) then
+                if (world%rank == world%root) then
+                    print *, "Provided squared buoyancy frequency:", bfsq
+                endif
+                return
+            endif
 
             bfsq = sum(buoy(nz, box%lo(2):box%hi(2), box%lo(1):box%hi(1))  &
                      - buoy(0,  box%lo(2):box%hi(2), box%lo(1):box%hi(1)))

--- a/src/utils/physics.f90
+++ b/src/utils/physics.f90
@@ -117,7 +117,7 @@ module physics
                print_physical_quantity_integer,     &
                print_physical_quantity_logical,     &
 #ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
-               l_bfsq,                             &
+               l_bfsq,                              &
 #endif
                print_physical_quantity_character
 

--- a/src/utils/physics.f90
+++ b/src/utils/physics.f90
@@ -101,9 +101,8 @@ module physics
     ! squared buoyancy frequency, N^2
     double precision, protected :: bfsq = zero
 
-    ! buoyancy frequency, N
-    double precision, protected :: bf   = zero
-    logical                     :: l_bfreq = .false.
+    ! Was N^2 provided?
+    logical                     :: l_bfsq = .false.
 #endif
 
     interface print_physical_quantity
@@ -118,7 +117,7 @@ module physics
                print_physical_quantity_integer,     &
                print_physical_quantity_logical,     &
 #ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
-               l_bfreq,                             &
+               l_bfsq,                             &
 #endif
                print_physical_quantity_character
 
@@ -204,10 +203,9 @@ module physics
                 call read_netcdf_attribute_default(grp_ncid, 'ape_calculation', ape_calculation)
 
 #ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
-                l_bfreq = has_attribute(grp_ncid, 'buoyancy_frequency')
-                if (l_bfreq) then
-                    call read_netcdf_attribute_default(grp_ncid, 'buoyancy_frequency', bf)
-                    bfsq = bf ** 2
+                l_bfsq = has_attribute(grp_ncid, 'squared_buoyancy_frequency')
+                if (l_bfsq) then
+                    call read_netcdf_attribute_default(grp_ncid, 'squared_buoyancy_frequency', bfsq)
                 endif
 #endif
 
@@ -271,8 +269,8 @@ module physics
             call write_netcdf_attribute(grp_ncid, 'ape_calculation', ape_calculation)
 
 #ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
-            if (l_bfreq) then
-                call write_netcdf_attribute(grp_ncid, 'buoyancy_frequency', bf)
+            if (l_bfsq) then
+                call write_netcdf_attribute(grp_ncid, 'squared_buoyancy_frequency', bf)
             endif
 #endif
 
@@ -302,8 +300,8 @@ module physics
             call print_physical_quantity('APE calculation', ape_calculation)
 
 #ifdef ENABLE_BUOYANCY_PERTURBATION_MODE
-            if (l_bfreq) then
-                call print_physical_quantity('buoyancy_frequency', bf, '1/s')
+            if (l_bfsq) then
+                call print_physical_quantity('squared_buoyancy_frequency', bf, '1/s^2')
             endif
 #endif
             write(*, *) ''
@@ -368,7 +366,7 @@ module physics
                                                  box%hlo(2):box%hhi(2),  &
                                                  box%hlo(1):box%hhi(1))
 
-            if (l_bfreq) then
+            if (l_bfsq) then
                 if (world%rank == world%root) then
                     print *, "Provided squared buoyancy frequency:", bfsq
                 endif
@@ -387,7 +385,6 @@ module physics
                                world%err)
 
             bfsq = bfsq / (dble(nx * ny) * zext)
-            bf = dsqrt(bfsq)
 
             if (world%rank == world%root) then
                 print *, "Calculated squared buoyancy frequency:", bfsq


### PR DESCRIPTION
We currently do not calculate the (squared) buoyancy frequency in restart mode. This PR changes to the buoyancy frequency (as input) and calculates only if not provided.