### PR TITLE
Fix rk_timer

### DIFF
--- a/src/3d/stepper/ls_rk.f90
+++ b/src/3d/stepper/ls_rk.f90
@@ -211,9 +211,9 @@ module ls_rk
 
             call parcel_communicate
 
-            call par2grid
-
             call stop_timer(rk_timer)
+
+            call par2grid
 
         end subroutine ls_rk_substep
 


### PR DESCRIPTION
Do not include `par2grid` timer in `rk_timer`.