### PR TITLE
Gridded strain

### DIFF
--- a/src/3d/fields/fields.f90
+++ b/src/3d/fields/fields.f90
@@ -50,12 +50,15 @@ module fields
         nparg,     &   ! number of parcels per grid box
         nsparg         ! number of small parcels per grid box
 
-    ! velocity strain indices
+    ! velocity strain indices (note that dw/dz is found from continuity)
     integer, parameter :: I_DUDX = 1 & ! index for du/dx strain component
                         , I_DUDY = 2 & ! index for du/dy strain component
-                        , I_DVDY = 3 & ! index for dv/dy strain component
-                        , I_DWDX = 4 & ! index for dw/dx strain component
-                        , I_DWDY = 5   ! index for dw/dy strain component
+                        , I_DUDZ = 3 & ! index for du/dz strain component
+                        , I_DVDX = 4 & ! index for dv/dy strain component
+                        , I_DVDY = 5 & ! index for dv/dy strain component
+                        , I_DVDZ = 6 & ! index for dv/dy strain component
+                        , I_DWDX = 7 & ! index for dw/dx strain component
+                        , I_DWDY = 8   ! index for dw/dy strain component
 
     contains
 
@@ -75,7 +78,7 @@ module fields
             hhi = box%hhi
 
             allocate(velog(hlo(3):hhi(3), hlo(2):hhi(2), hlo(1):hhi(1), n_dim))
-            allocate(velgradg(hlo(3):hhi(3), hlo(2):hhi(2), hlo(1):hhi(1), 5))
+            allocate(velgradg(hlo(3):hhi(3), hlo(2):hhi(2), hlo(1):hhi(1), 8))
 
             allocate(volg(hlo(3):hhi(3), hlo(2):hhi(2), hlo(1):hhi(1)))
             allocate(strain_mag(hlo(3):hhi(3), hlo(2):hhi(2), hlo(1):hhi(1)))

--- a/src/3d/fields/fields.f90
+++ b/src/3d/fields/fields.f90
@@ -54,9 +54,9 @@ module fields
     integer, parameter :: I_DUDX = 1 & ! index for du/dx strain component
                         , I_DUDY = 2 & ! index for du/dy strain component
                         , I_DUDZ = 3 & ! index for du/dz strain component
-                        , I_DVDX = 4 & ! index for dv/dy strain component
+                        , I_DVDX = 4 & ! index for dv/dx strain component
                         , I_DVDY = 5 & ! index for dv/dy strain component
-                        , I_DVDZ = 6 & ! index for dv/dy strain component
+                        , I_DVDZ = 6 & ! index for dv/dz strain component
                         , I_DWDX = 7 & ! index for dw/dx strain component
                         , I_DWDY = 8   ! index for dw/dy strain component
 

--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -305,14 +305,14 @@ module inversion_mod
             velgradg(nz+1, :, :, I_DWDY) = -velgradg(nz-1, :, :, I_DWDY)
             !$omp end parallel workshare
 
-            call field_halo_fill_vector(velgradg, l_alloc=.true.)
-
             !$omp parallel workshare
             ! fill the other components
             velgradg(:, :, :, I_DUDZ) = velgradg(:, :, :, I_DWDX) + vortg(:, :, :,  I_Y) 
             velgradg(:, :, :, I_DVDX) = velgradg(:, :, :, I_DUDY) + vortg(:, :, :,  I_Z) 
             velgradg(:, :, :, I_DVDZ) = velgradg(:, :, :, I_DWDY) - vortg(:, :, :,  I_X)
             !$omp end parallel workshare
+
+            call field_halo_fill_vector(velgradg, l_alloc=.true.)
 
         end subroutine vel2vgrad
 

--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -307,6 +307,13 @@ module inversion_mod
 
             call field_halo_fill_vector(velgradg, l_alloc=.true.)
 
+            !$omp parallel workshare
+            ! fill the other components
+            velgradg(:, :, :, I_DUDZ) = velgradg(:, :, :, I_DWDX) + vortg(:, :, :,  I_Y) 
+            velgradg(:, :, :, I_DVDX) = velgradg(:, :, :, I_DUDY) + vortg(:, :, :,  I_Z) 
+            velgradg(:, :, :, I_DVDZ) = velgradg(:, :, :, I_DWDY) - vortg(:, :, :,  I_X)
+            !$omp end parallel workshare
+
         end subroutine vel2vgrad
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -54,7 +54,10 @@ module parcel_container
                           IDX_RK4_DB23,     & ! RK4 variable for B23
                           IDX_RK4_DUDX,     & ! RK4 variable du/dx
                           IDX_RK4_DUDY,     & ! RK4 variable du/dy
+                          IDX_RK4_DUDZ,     & ! RK4 variable du/dz
+                          IDX_RK4_DVDX,     & ! RK4 variable dv/dx
                           IDX_RK4_DVDY,     & ! RK4 variable dv/dy
+                          IDX_RK4_DVDZ,     & ! RK4 variable dv/dz
                           IDX_RK4_DWDX,     & ! RK4 variable dw/dx
                           IDX_RK4_DWDY        ! RK4 variable dw/dy
 
@@ -130,11 +133,14 @@ module parcel_container
             IDX_RK4_DB23 = i + 10
             IDX_RK4_DUDX = i + 11
             IDX_RK4_DUDY = i + 12
-            IDX_RK4_DVDY = i + 13
-            IDX_RK4_DWDX = i + 14
-            IDX_RK4_DWDY = i + 15
+            IDX_RK4_DUDZ = i + 13
+            IDX_RK4_DVDX = i + 14
+            IDX_RK4_DVDY = i + 15
+            IDX_RK4_DVDZ = i + 16
+            IDX_RK4_DWDX = i + 17
+            IDX_RK4_DWDY = i + 18
 
-            i = i + 16
+            i = i + 19
 
             n_par_attrib = set_ellipsoid_buffer_indices(i)
 
@@ -315,7 +321,7 @@ module parcel_container
             ! LS-RK4 variables
             allocate(parcels%delta_pos(3, num))
             allocate(parcels%delta_vor(3, num))
-            allocate(parcels%strain(5, num))
+            allocate(parcels%strain(8, num))
             allocate(parcels%delta_b(5, num))
 
         end subroutine parcel_alloc

--- a/src/3d/parcels/parcel_interpl.f90
+++ b/src/3d/parcels/parcel_interpl.f90
@@ -459,7 +459,7 @@ module parcel_interpl
                         parcels%delta_pos(l, n) = parcels%delta_pos(l, n) &
                                                 + point_weight_g2p * sum(weights * velog(ks:ks+1, js:js+1, is:is+1, l))
                     enddo
-                    do l = 1,5
+                    do l = 1,8
                         parcels%strain(l, n) = parcels%strain(l, n) &
                                              + point_weight_g2p * sum(weights * velgradg(ks:ks+1, js:js+1, is:is+1, l))
                     enddo

--- a/src/3d/stepper/ls_rk.f90
+++ b/src/3d/stepper/ls_rk.f90
@@ -153,7 +153,6 @@ module ls_rk
                 do n = 1, n_parcels
                     parcels%delta_b(:, n) = get_dBdt(parcels%B(:, n),           &
                                                      parcels%strain(:, n),      &
-                                                     parcels%vorticity(:, n),   &
                                                      parcels%volume(n))
                 enddo
                 !$omp end parallel do
@@ -173,7 +172,6 @@ module ls_rk
                     parcels%delta_b(:, n) = parcels%delta_b(:, n)               &
                                           + get_dBdt(parcels%B(:, n),           &
                                                      parcels%strain(:, n),      &
-                                                     parcels%vorticity(:, n),   &
                                                      parcels%volume(n))
                 enddo
                 !$omp end parallel do

--- a/src/3d/stepper/rk_utils.f90
+++ b/src/3d/stepper/rk_utils.f90
@@ -31,7 +31,7 @@ module rk_utils
             double precision, intent(in) :: S(8)
             double precision, intent(in) :: volume
             double precision             :: Bout(5), B33
-            double precision             :: dudz, dvdx, dvdz, dwdz
+            double precision             :: dwdz
 
             ! dw/dz = - (du/dx + dv/dy)
             dwdz = - (S(I_DUDX) + S(I_DVDY))

--- a/src/3d/stepper/rk_utils.f90
+++ b/src/3d/stepper/rk_utils.f90
@@ -1,7 +1,7 @@
 module rk_utils
     use dimensions, only : n_dim, I_X, I_Y, I_Z
     use parcel_ellipsoid, only : get_B33, I_B11, I_B12, I_B13, I_B22, I_B23
-    use fields, only : velgradg, tbuoyg, vortg, I_DUDX, I_DUDY, I_DVDY, I_DWDX, I_DWDY, strain_mag
+    use fields, only : velgradg, tbuoyg, vortg, I_DUDX, I_DUDY, I_DUDZ, I_DVDX, I_DVDY, I_DVDZ, I_DWDX, I_DWDY, strain_mag
     use field_mpi, only : field_halo_fill_scalar
     use constants, only : zero, one, two, f12
     use parameters, only : nx, ny, nz, dxi, vcell
@@ -28,20 +28,11 @@ module rk_utils
         ! @returns dB/dt in Bout
         function get_dBdt(Bin, S, vorticity, volume) result(Bout)
             double precision, intent(in) :: Bin(I_B23)
-            double precision, intent(in) :: S(5)
+            double precision, intent(in) :: S(8)
             double precision, intent(in) :: vorticity(n_dim)
             double precision, intent(in) :: volume
             double precision             :: Bout(5), B33
             double precision             :: dudz, dvdx, dvdz, dwdz
-
-            ! du/dz = \eta + dw/dx
-            dudz = vorticity(I_Y) + S(I_DWDX)
-
-            ! dv/dx \zeta + du/dy
-            dvdx = vorticity(I_Z) + S(I_DUDY)
-
-            ! dv/dz = dw/dy - \xi
-            dvdz = S(I_DWDY) - vorticity(I_X)
 
             ! dw/dz = - (du/dx + dv/dy)
             dwdz = - (S(I_DUDX) + S(I_DVDY))
@@ -49,31 +40,31 @@ module rk_utils
             B33 = get_B33(Bin, volume)
 
             ! dB11/dt = 2 * (du/dx * B11 + du/dy * B12 + du/dz * B13)
-            Bout(I_B11) = two * (S(I_DUDX) * Bin(I_B11) + S(I_DUDY) * Bin(I_B12) + dudz * Bin(I_B13))
+            Bout(I_B11) = two * (S(I_DUDX) * Bin(I_B11) + S(I_DUDY) * Bin(I_B12) + S(I_DUDZ) * Bin(I_B13))
 
             ! dB12/dt =
-            Bout(I_B12) = dvdx      * Bin(I_B11) & !   dv/dx * B11
+            Bout(I_B12) = S(I_DVDX) * Bin(I_B11) & !   dv/dx * B11
                         - dwdz      * Bin(I_B12) & ! - dw/dz * B12
-                        + dvdz      * Bin(I_B13) & ! + dv/dz * B13
+                        + S(I_DVDZ) * Bin(I_B13) & ! + dv/dz * B13
                         + S(I_DUDY) * Bin(I_B22) & ! + du/dy * B22
-                        + dudz      * Bin(I_B23)   ! + du/dz * B23
+                        + S(I_DUDZ) * Bin(I_B23)   ! + du/dz * B23
 
             ! dB13/dt =
             Bout(I_B13) = S(I_DWDX) * Bin(I_B11) & !   dw/dx * B11
                         + S(I_DWDY) * Bin(I_B12) & ! + dw/dy * B12
                         - S(I_DVDY) * Bin(I_B13) & ! - dv/dy * B13
                         + S(I_DUDY) * Bin(I_B23) & ! + du/dy * B23
-                        + dudz      * B33          ! + du/dz * B33
+                        + S(I_DUDZ) * B33          ! + du/dz * B33
 
             ! dB22/dt = 2 * (dv/dx * B12 + dv/dy * B22 + dv/dz * B23)
-            Bout(I_B22) = two * (dvdx * Bin(I_B12) + S(I_DVDY) * Bin(I_B22) + dvdz * Bin(I_B23))
+            Bout(I_B22) = two * (S(I_DVDX) * Bin(I_B12) + S(I_DVDY) * Bin(I_B22) + S(I_DVDZ) * Bin(I_B23))
 
             ! dB23/dt =
             Bout(I_B23) = S(I_DWDX) * Bin(I_B12) & !   dw/dx * B12
-                        + dvdx      * Bin(I_B13) & ! + dv/dx * B13
+                        + S(I_DVDX) * Bin(I_B13) & ! + dv/dx * B13
                         + S(I_DWDY) * Bin(I_B22) & ! + dw/dy * B22
                         - S(I_DUDX) * Bin(I_B23) & ! - du/dx * B23
-                        + dvdz      * B33          ! + dv/dz * B33
+                        + S(I_DVDZ) * B33          ! + dv/dz * B33
         end function get_dBdt
 
         ! Calculate velocity strain
@@ -81,7 +72,7 @@ module rk_utils
         ! @param[in] vorticity at grid point
         ! @returns 3x3 strain matrix
         function get_strain(velgradgp, vortgp) result(strain)
-            double precision, intent(in) :: velgradgp(5)
+            double precision, intent(in) :: velgradgp(8)
             double precision, intent(in) :: vortgp(n_dim)
             double precision             :: strain(3,3)
        

--- a/src/3d/stepper/rk_utils.f90
+++ b/src/3d/stepper/rk_utils.f90
@@ -26,10 +26,9 @@ module rk_utils
         ! @param[in] vorticity of parcel
         ! @param[in] volume is the parcel volume
         ! @returns dB/dt in Bout
-        function get_dBdt(Bin, S, vorticity, volume) result(Bout)
+        function get_dBdt(Bin, S, volume) result(Bout)
             double precision, intent(in) :: Bin(I_B23)
             double precision, intent(in) :: S(8)
-            double precision, intent(in) :: vorticity(n_dim)
             double precision, intent(in) :: volume
             double precision             :: Bout(5), B33
             double precision             :: dudz, dvdx, dvdz, dwdz

--- a/unit-tests/3d/test_mpi_parcel_read.f90
+++ b/unit-tests/3d/test_mpi_parcel_read.f90
@@ -9,13 +9,14 @@ program test_mpi_parcel_read
     use parcel_container
     use parameters, only : set_max_num_parcels
     use parcel_netcdf
+    use netcdf_utils
     use mpi_environment
     use mpi_timer
     implicit none
 
     logical              :: passed = .true.
     double precision     :: res
-    integer              :: n, start_index, n_parcels_before
+    integer              :: n, start_index, n_parcels_before 
 
     call set_max_num_parcels(100000000)
 

--- a/unit-tests/3d/test_mpi_parcel_read_rejection.f90
+++ b/unit-tests/3d/test_mpi_parcel_read_rejection.f90
@@ -7,12 +7,17 @@
 ! =============================================================================
 program test_mpi_parcel_read_rejection
     use unit_test
-    use options, only : parcel
-    use constants, only : zero, f12
+    use options, only : parcel, write_netcdf_options
+    use constants, only : one, zero, f12
     use parcel_container
     use parcel_netcdf
     use mpi_environment
     use mpi_layout
+    use netcdf_utils
+    use netcdf_writer
+    use physics, only : write_physical_quantities
+    use config, only : package_version, cf_version
+    use iomanip, only : zfill
     use parameters, only : lower, update_parameters, extent, nx, ny, nz, dx, max_num_parcels
     use mpi_timer
     implicit none

--- a/unit-tests/3d/test_mpi_parcel_write.f90
+++ b/unit-tests/3d/test_mpi_parcel_write.f90
@@ -1,4 +1,4 @@
-! =============================================================================
+! ============================================================================r
 !                           Test parallel parcel writing
 !
 !       This unit test checks the writing of parcels in parallel.
@@ -8,6 +8,7 @@ program test_mpi_parcel_write
     use constants, only : zero
     use parcel_container
     use parcel_netcdf
+    use netcdf_utils
     use mpi_environment
     use mpi_timer
     implicit none


### PR DESCRIPTION
This branch uses only gridded strain field to deform parcels. Changes to save B33 and use matrix exponentiation not yet included.