### PR TITLE
Add optimised rejection method

### DIFF
--- a/mpi-tests/benchmark_parcel_merging.f90
+++ b/mpi-tests/benchmark_parcel_merging.f90
@@ -120,13 +120,13 @@ program benchmark_parcel_merging
     call mpi_blocking_reduce(buf, MPI_SUM, world)
 
     n_parcel_merges = buf(1)
-    n_big_close = buf(2)
+!     n_big_close = buf(2)
     n_way_parcel_mergers = buf(3:9)
 
     if (world%rank == world%root) then
         print *, "Number of MPI ranks:        ", world%size
         print *, "Total number of merges:     ", n_parcel_merges
-        print *, "Number of close big parcels:", n_big_close
+        print *, "Number of close big parcels:", buf(2) !n_big_close
         do k = 1, 7
             write(snum, fmt='(I1)')  k+1
             print *, "Number of " // snum // "-way mergers:    ", n_way_parcel_mergers(k)

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -407,7 +407,9 @@ module parcel_netcdf
                 ! (reject all parcels that are not part of
                 !  the sub-domain owned by *this* MPI rank)
                 !
-                call mpi_print("WARNING: The start index is not provided. All MPI ranks read all parcels!")
+                call mpi_print("WARNING: Unable to retrieve information for fast parcel reading.")
+                call mpi_print("         All MPI ranks read all parcels!")
+
                 start_index = 1
                 end_index = min(max_num_parcels, n_total)
                 pfirst = 1

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -345,8 +345,7 @@ module parcel_netcdf
                     end_index = start(2) - 1
                 else
                     ! the last MPI rank must only read the start index
-                    call read_netcdf_dataset(ncid, 'start_index', start, (/num_indices/), (/1/))
-                    start_index = start(1)
+                    call read_netcdf_dataset(ncid, 'start_index', start_index, num_indices)
                     end_index = n_total
                 endif
 
@@ -384,14 +383,13 @@ module parcel_netcdf
 
                         ! get start and end index:
                         if (n < num_indices) then
-                            call read_netcdf_dataset(ncid, 'start_index', start, (/world%rank + 1/), (/2/))
+                            call read_netcdf_dataset(ncid, 'start_index', start, (/n/), (/2/))
                             start_index = start(1)
                             ! we must subtract 1, otherwise rank reads the first parcel of the next domain
                             end_index = start(2) - 1
                         else
                             ! for the last index we can only read the start index
-                            call read_netcdf_dataset(ncid, 'start_index', start, (/num_indices/), (/1/))
-                            start_index = start(1)
+                            call read_netcdf_dataset(ncid, 'start_index', start_index, num_indices)
                             call get_num_parcels(ncid, n_total)
                             end_index = n_total
                         endif

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -391,6 +391,7 @@ module parcel_netcdf
                             ! for the last index we can only read the start index
                             call read_netcdf_dataset(ncid, 'start_index', start, (/num_indices/), (/1/))
                             start_index = start(1)
+                            call get_num_parcels(ncid, n_total)
                             end_index = n_total
                         endif
 

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -379,7 +379,8 @@ module parcel_netcdf
                     call read_netcdf_dataset(ncid, 'yhi', yhi, start=n)
 
                     ! check if box overlap (19 April 2024, https://stackoverflow.com/a/3269471):
-                    if ((xlo <= yhi) .and. (ylo <= xhi)) then
+                    if ((xlo <= box%hi(1)) .and. (box%lo(1) <= xhi) .and. &
+                        (ylo <= box%hi(2)) .and. (box%lo(2) <= yhi)) then
 
                         ! get start and end index:
                         if (n < num_indices) then

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -381,7 +381,7 @@ module parcel_netcdf
                     ! check if box overlap (19 April 2024, https://stackoverflow.com/a/3269471):
                     if ((xlo <= yhi) .and. (ylo <= xhi)) then
 
-                        ! get start and end end index:
+                        ! get start and end index:
                         if (n < num_indices) then
                             call read_netcdf_dataset(ncid, 'start_index', start, (/world%rank + 1/), (/2/))
                             start_index = start(1)

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -394,7 +394,6 @@ module parcel_netcdf
                             end_index = n_total
                         endif
 
-                        pfirst = 1
                         n_total = end_index - start_index + 1
                         call rejection_method(start_index, n_total, pfirst)
 

--- a/src/netcdf/netcdf_reader.f90
+++ b/src/netcdf/netcdf_reader.f90
@@ -15,6 +15,7 @@ module netcdf_reader
         module procedure :: read_netcdf_dataset_2d
         module procedure :: read_netcdf_dataset_3d
         module procedure :: read_netcdf_dataset_1d_integer
+        module procedure :: read_netcdf_dataset_1d_integer_scalar
     end interface read_netcdf_dataset
 
     interface read_netcdf_attribute
@@ -172,6 +173,22 @@ module netcdf_reader
             ncerr = nf90_get_var(ncid=ncid, varid=varid, values=buffer, &
                                  start=start, count=cnt)
         end subroutine read_netcdf_dataset_1d_integer
+
+        subroutine read_netcdf_dataset_1d_integer_scalar(ncid, name, val, start)
+            integer,           intent(in)  :: ncid
+            character(*),      intent(in)  :: name
+            integer,           intent(out) :: val
+            integer, optional, intent(in)  :: start
+            integer                        :: varid, buffer(1)
+
+            ncerr = nf90_inq_varid(ncid, name, varid)
+            call check_netcdf_error("Reading dataset id failed.")
+
+            ncerr = nf90_get_var(ncid=ncid, varid=varid, values=buffer, &
+                                 start=(/start/), count=(/1/))
+
+            val = buffer(1)
+        end subroutine read_netcdf_dataset_1d_integer_scalar
 
         subroutine read_netcdf_dataset_1d(ncid, name, buffer, start, cnt)
             integer,           intent(in)  :: ncid


### PR DESCRIPTION
This PR adds an optimised rejection method for reading a parcel dataset. If the dataset contains the MPI decomposition boxes and start indices, they will be used to selectively read parcels, i.e. not all MPI ranks read all parcels. This increases the performance for restarts from parcel files using different number of MPI ranks as the written restart file.