### PR TITLE
Add labels to code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -421,6 +421,21 @@ else
     AC_MSG_RESULT([no])
 fi
 
+ENABLE_LABELS='no'
+AC_ARG_ENABLE([labels],
+              [AS_HELP_STRING([--enable-labels], [enable labels (default=no)])],
+              [ENABLE_LABELS=$enableval])
+
+AM_CONDITIONAL([ENABLE_LABELS], [test "$ENABLE_LABELS" = "yes"])
+
+AC_MSG_CHECKING([whether we are compiling with labels])
+if test "x$ENABLE_LABELS" = "xyes"; then
+    AC_MSG_RESULT([yes])
+    FCFLAGS="$FCFLAGS -DENABLE_LABELS"
+else
+    AC_MSG_RESULT([no])
+fi
+
 ENABLE_P2G_1POINT='no'
 AC_ARG_ENABLE([p2g-1point],
               [AS_HELP_STRING([--enable-p2g-1point], [enable one-point par2grid (default=no)])],

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -434,7 +434,7 @@ module parcel_container
             parcels%humidity(n)     = buffer(IDX_HUM)
 #endif
 #ifndef ENABLE_DRY_MODE
-            parcels%label(n)        = buffer(IDX_LABEL)
+            parcels%label(n)        = nint(buffer(IDX_LABEL))
             parcels%dilution(n)     = buffer(IDX_DILUTION)
 #endif
             ! LS-RK4 variables:

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -41,6 +41,10 @@ module parcel_container
 #ifndef ENABLE_DRY_MODE
                           IDX_HUM,          & ! humidity
 #endif
+#ifdef ENABLE_LABELS
+                          IDX_LABEL,        & ! label
+                          IDX_DILUTION,     & ! dilution
+#endif
                           IDX_RK4_X_DPOS,   & ! RK4 variable delta x-position
                           IDX_RK4_Y_DPOS,   & ! RK4 variable delta y-position
                           IDX_RK4_Z_DPOS,   & ! RK4 variable delta z-position
@@ -78,6 +82,9 @@ module parcel_container
 #ifndef ENABLE_DRY_MODE
             humidity,   &
 #endif
+#ifdef ENABLE_LABELS
+            dilution,   &
+#endif
             buoyancy
 
         ! LS-RK4 variables
@@ -86,6 +93,12 @@ module parcel_container
             delta_vor,  &   ! vorticity tendency
             strain,     &
             delta_b         ! B-matrix tendency
+
+#ifdef ENABLE_LABELS
+        integer(kind=8), allocatable, dimension(:) :: &
+            label
+#endif
+
     end type parcel_container_type
 
     type(parcel_container_type) parcels
@@ -117,6 +130,11 @@ module parcel_container
 #ifndef ENABLE_DRY_MODE
             IDX_HUM  = i
             i = i + 1
+#endif
+#ifdef ENABLE_LABELS
+            IDX_LABEL  = i
+            IDX_DILUTION  = i +1
+            i = i + 2
 #endif
 
             ! LS-RK4 variables
@@ -250,6 +268,10 @@ module parcel_container
 #ifndef ENABLE_DRY_MODE
             parcels%humidity(n)     = parcels%humidity(m)
 #endif
+#ifdef ENABLE_LABELS
+            parcels%label(n)        = parcels%label(m)
+            parcels%dilution(n)     = parcels%dilution(m)
+#endif
             parcels%B(:, n)         = parcels%B(:, m)
 
             call parcel_ellipsoid_replace(n, m)
@@ -287,6 +309,10 @@ module parcel_container
 #ifndef ENABLE_DRY_MODE
             call resize_array(parcels%humidity, new_size, n_parcels)
 #endif
+#ifdef ENABLE_LABELS
+            call resize_array(parcels%label, new_size, n_parcels)
+            call resize_array(parcels%dilution, new_size, n_parcels)
+#endif
             call parcel_ellipsoid_resize(new_size, n_parcels)
 
             ! LS-RK4 variables
@@ -315,6 +341,10 @@ module parcel_container
             allocate(parcels%buoyancy(num))
 #ifndef ENABLE_DRY_MODE
             allocate(parcels%humidity(num))
+#endif
+#ifdef ENABLE_LABELS
+            allocate(parcels%label(num))
+            allocate(parcels%dilution(num))
 #endif
             call parcel_ellipsoid_allocate(num)
 
@@ -345,6 +375,10 @@ module parcel_container
             deallocate(parcels%buoyancy)
 #ifndef ENABLE_DRY_MODE
             deallocate(parcels%humidity)
+#endif
+#ifdef ENABLE_LABELS
+            deallocate(parcels%label)
+            deallocate(parcels%dilution)
 #endif
             call parcel_ellipsoid_deallocate
 

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -405,6 +405,10 @@ module parcel_container
 #ifndef ENABLE_DRY_MODE
             buffer(IDX_HUM)             = parcels%humidity(n)
 #endif
+#ifdef ENABLE_LABELS
+            buffer(IDX_LABEL)           = parcels%label(n)
+            buffer(IDX_DILUTION)        = parcels%dilution(n)
+#endif
             ! LS-RK4 variables:
             buffer(IDX_RK4_X_DPOS:IDX_RK4_Z_DPOS) = parcels%delta_pos(:, n)
             buffer(IDX_RK4_X_DVOR:IDX_RK4_Z_DVOR) = parcels%delta_vor(:, n)
@@ -428,6 +432,10 @@ module parcel_container
             parcels%buoyancy(n)     = buffer(IDX_BUO)
 #ifndef ENABLE_DRY_MODE
             parcels%humidity(n)     = buffer(IDX_HUM)
+#endif
+#ifndef ENABLE_DRY_MODE
+            parcels%label(n)        = buffer(IDX_LABEL)
+            parcels%dilution(n)     = buffer(IDX_DILUTION)
 #endif
             ! LS-RK4 variables:
             parcels%delta_pos(:, n) = buffer(IDX_RK4_X_DPOS:IDX_RK4_Z_DPOS)

--- a/src/3d/parcels/parcel_init.f90
+++ b/src/3d/parcels/parcel_init.f90
@@ -140,13 +140,13 @@ module parcel_init
                                     parcels%position(1, l) = corner(1) + dx(1) * (dble(i) - f12) * im
                                     parcels%position(2, l) = corner(2) + dx(2) * (dble(j) - f12) * im
                                     parcels%position(3, l) = corner(3) + dx(3) * (dble(k) - f12) * im
-                                    l = l + 1
 #ifdef ENABLE_LABELS
                                     parcels%label(l)=1 + (ix * n_per_dim + i) + &
                                                      (nx * n_per_dim) * ((iy * n_per_dim + j) + &
                                                      (ny * n_per_dim) * (iz * n_per_dim + k))
                                     parcels%dilution(l)=1.0
 #endif
+                                    l = l + 1
                                 enddo
                             enddo
                         enddo

--- a/src/3d/parcels/parcel_init.f90
+++ b/src/3d/parcels/parcel_init.f90
@@ -141,9 +141,9 @@ module parcel_init
                                     parcels%position(2, l) = corner(2) + dx(2) * (dble(j) - f12) * im
                                     parcels%position(3, l) = corner(3) + dx(3) * (dble(k) - f12) * im
 #ifdef ENABLE_LABELS
-                                    parcels%label(l)=1 + (ix * n_per_dim + i) + &
-                                                     (nx * n_per_dim) * ((iy * n_per_dim + j) + &
-                                                     (ny * n_per_dim) * (iz * n_per_dim + k))
+                                    parcels%label(l)=1 + (ix * n_per_dim + (i - 1)) + &
+                                                     (nx * n_per_dim) * ((iy * n_per_dim + (j - 1)) + &
+                                                     (ny * n_per_dim) * (iz * n_per_dim + (k - 1)))
                                     parcels%dilution(l)=1.0
 #endif
                                     l = l + 1

--- a/src/3d/parcels/parcel_init.f90
+++ b/src/3d/parcels/parcel_init.f90
@@ -141,6 +141,12 @@ module parcel_init
                                     parcels%position(2, l) = corner(2) + dx(2) * (dble(j) - f12) * im
                                     parcels%position(3, l) = corner(3) + dx(3) * (dble(k) - f12) * im
                                     l = l + 1
+#ifdef ENABLE_LABELS
+                                    parcels%label(l)=1 + (ix * n_per_dim + i) + &
+                                                     (nx * n_per_dim) * ((iy * n_per_dim + j) + &
+                                                     (ny * n_per_dim) * (iz * n_per_dim + k))
+                                    parcels%dilution(l)=1.0
+#endif
                                 enddo
                             enddo
                         enddo

--- a/src/3d/parcels/parcel_init.f90
+++ b/src/3d/parcels/parcel_init.f90
@@ -144,7 +144,7 @@ module parcel_init
                                     parcels%label(l)=1 + (ix * n_per_dim + (i - 1)) + &
                                                      (nx * n_per_dim) * ((iy * n_per_dim + (j - 1)) + &
                                                      (ny * n_per_dim) * (iz * n_per_dim + (k - 1)))
-                                    parcels%dilution(l)=1.0
+                                    parcels%dilution(l)=0.0
 #endif
                                     l = l + 1
                                 enddo

--- a/src/3d/parcels/parcel_merge.f90
+++ b/src/3d/parcels/parcel_merge.f90
@@ -199,7 +199,7 @@ module parcel_merging
                 ! This could be optimised moving it to later in code
                 call random_number(rn) 
                 if(rn*(vm(n)+parcels%volume(is))<vm(n)) then
-                   dilm(n)=dilm(n)*vm(m)/(vm(n)+parcels%volume(is))
+                   dilm(n)=dilm(n)*vm(n)/(vm(n)+parcels%volume(is))
                 else
                    labelm(n)=parcels%label(is)
                    dilm(n)=parcels%dilution(is)*parcels%volume(is)/(vm(n)+parcels%volume(is))

--- a/src/3d/parcels/parcel_merge.f90
+++ b/src/3d/parcels/parcel_merge.f90
@@ -131,6 +131,11 @@ module parcel_merging
 #ifndef ENABLE_DRY_MODE
             double precision                :: hum(n_merge)
 #endif
+#ifdef ENABLE_LABELS
+            double precision                :: labelm(n_merge)
+            double precision                :: dilm(n_merge)
+            double precision                :: rn
+#endif
             double precision, intent(out)   :: Bm(6, n_merge) ! B11, B12, B13, B22, B23, B33
             double precision, intent(out)   :: vm(n_merge)
 
@@ -176,12 +181,30 @@ module parcel_merging
                     vortm(:, l) = parcels%volume(ic) * parcels%vorticity(:, ic)
 
                     Bm(:, l) = zero
+
+#ifdef ENABLE_LABELS
+                    labelm(l) = parcels%label(ic)
+
+                    dilm(l) = parcels%dilution(ic)
+#endif
                 endif
 
                 ! Sum up all the small parcels merging with a common other one:
                 ! "is" refers to the small parcel index
                 is = isma(m) !Small parcel
                 n = loca(ic)  !Index of merged parcel
+
+#ifdef ENABLE_LABELS
+                ! Dilute the parcel when volume is added for now
+                ! This could be optimised moving it to later in code
+                call random_number(rn) 
+                if(rn*(vm(n)+parcels%volume(is))<vm(n)) then
+                   dilm(n)=dilm(n)*vm(m)/(vm(n)+parcels%volume(is))
+                else
+                   labelm(n)=parcels%label(is)
+                   dilm(n)=parcels%dilution(is)*parcels%volume(is)/(vm(n)+parcels%volume(is))
+                endif
+#endif
                 vm(n) = vm(n) + parcels%volume(is) !Accumulate volume of merged parcel
 
                 ! works across periodic edge
@@ -268,6 +291,10 @@ module parcel_merging
                     parcels%buoyancy(ic) = buoym(l)
 #ifndef ENABLE_DRY_MODE
                     parcels%humidity(ic) = hum(l)
+#endif
+#ifdef ENABLE_LABELS
+                    parcels%label(ic) = labelm(l)
+                    parcels%dilution(ic) = dilm(l)
 #endif
                     parcels%vorticity(:, ic) = vortm(:, l)
 

--- a/src/3d/parcels/parcel_merge.f90
+++ b/src/3d/parcels/parcel_merge.f90
@@ -199,10 +199,10 @@ module parcel_merging
                 ! This could be optimised moving it to later in code
                 call random_number(rn) 
                 if(rn*(vm(n)+parcels%volume(is))<vm(n)) then
-                   dilm(n)=dilm(n)*vm(n)/(vm(n)+parcels%volume(is))
+                   dilm(n)=dilm(n)+log(vm(n)/(vm(n)+parcels%volume(is)))
                 else
                    labelm(n)=parcels%label(is)
-                   dilm(n)=parcels%dilution(is)*parcels%volume(is)/(vm(n)+parcels%volume(is))
+                   dilm(n)=parcels%dilution(is)+log(parcels%volume(is)/(vm(n)+parcels%volume(is)))
                 endif
 #endif
                 vm(n) = vm(n) + parcels%volume(is) !Accumulate volume of merged parcel

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -777,7 +777,7 @@ module parcel_netcdf
                                           dtype=NF90_INT64)
 
             nc_dset(NC_DILUTION) = netcdf_info(name='dilution',                    &
-                                          long_name='parcel dilution',             &
+                                          long_name='parcel log dilution',         &
                                           std_name='',                             &
                                           unit='1',                                &
                                           dtype=NF90_DOUBLE)

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -52,12 +52,14 @@ module parcel_netcdf
     logical :: l_first_write = .true.
 
 #ifndef ENABLE_DRY_MODE
-    integer, parameter :: NC_HUM   = 15
-
-    type(netcdf_info) :: nc_dset(NC_HUM)
-#else
-    type(netcdf_info) :: nc_dset(NC_B23)
+    integer, parameter  :: NC_HUM = 15 
 #endif
+#ifdef ENABLE_LABELS
+    integer, parameter :: NC_LABEL = 16 & 
+                       ,  NC_DILUTION = 17 
+#endif
+
+    type(netcdf_info) :: nc_dset(17)
 
     public :: create_netcdf_parcel_file &
             , write_netcdf_parcels      &
@@ -243,6 +245,10 @@ module parcel_netcdf
 #ifndef ENABLE_DRY_MODE
             call write_parcel_attribute(NC_HUM, parcels%humidity, start, cnt)
 #endif
+#ifdef ENABLE_LABELS
+            call write_parcel_attribute_int(NC_LABEL, parcels%label, start, cnt)
+            call write_parcel_attribute(NC_DILUTION, parcels%dilution, start, cnt)
+#endif
             ! increment counter
             n_writes = n_writes + 1
 
@@ -265,6 +271,18 @@ module parcel_netcdf
                                           start, cnt)
             endif
         end subroutine write_parcel_attribute
+
+        subroutine write_parcel_attribute_int(id, pdata, start, cnt)
+            integer,          intent(in) :: id
+            integer(kind=8),  intent(in) :: pdata(:)
+            integer,          intent(in) :: cnt(2), start(2)
+
+            if (nc_dset(id)%l_enabled) then
+                call write_netcdf_dataset(ncid, nc_dset(id)%varid,  &
+                                          pdata(1:n_parcels),       &
+                                          start, cnt)
+            endif
+        end subroutine write_parcel_attribute_int
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -515,6 +533,19 @@ module parcel_netcdf
                                          parcels%humidity(pfirst:plast), start, cnt)
             endif
 #endif
+#ifdef ENABLE_LABELS
+            if (has_dataset(ncid, 'label')) then
+                l_valid = .true.
+                call read_netcdf_dataset(ncid, 'label', &
+                                         parcels%label(pfirst:plast), start, cnt)
+            endif
+            if (has_dataset(ncid, 'dilution')) then
+                l_valid = .true.
+                call read_netcdf_dataset(ncid, 'dilution', &
+                                         parcels%dilution(pfirst:plast), start, cnt)
+            endif
+#endif
+
 
             if (.not. l_valid) then
                 call mpi_exit_on_error(&
@@ -543,6 +574,10 @@ module parcel_netcdf
                 nc_dset(NC_BUOY)%l_enabled  = .true.
 #ifndef ENABLE_DRY_MODE
                 nc_dset(NC_HUM)%l_enabled   = .true.
+#endif
+#ifdef ENABLE_LABELS
+                nc_dset(NC_LABEL)%l_enabled   = .true.
+                nc_dset(NC_DILUTION)%l_enabled   = .true.
 #endif
                 nc_dset(NC_VOL)%l_enabled   = .true.
                 nc_dset(NC_START)%l_enabled = .true.
@@ -582,6 +617,10 @@ module parcel_netcdf
                 nc_dset(NC_BUOY)%l_enabled  = .true.
 #ifndef ENABLE_DRY_MODE
                 nc_dset(NC_HUM)%l_enabled   = .true.
+#endif
+#ifdef ENABLE_LABELS
+                nc_dset(NC_LABEL)%l_enabled   = .true.
+                nc_dset(NC_DILUTION)%l_enabled   = .true.
 #endif
                 nc_dset(NC_VOL)%l_enabled   = .true.
                 nc_dset(NC_B11)%l_enabled   = .true.
@@ -726,6 +765,19 @@ module parcel_netcdf
 #ifndef ENABLE_DRY_MODE
             nc_dset(NC_HUM) = netcdf_info(name='humidity',                         &
                                           long_name='parcel humidity',             &
+                                          std_name='',                             &
+                                          unit='1',                                &
+                                          dtype=NF90_DOUBLE)
+#endif
+#ifdef ENABLE_LABELS
+            nc_dset(NC_LABEL) = netcdf_info(name='label',                          &
+                                          long_name='parcel label',                &
+                                          std_name='',                             &
+                                          unit='1',                                &
+                                          dtype=NF90_INT64)
+
+            nc_dset(NC_DILUTION) = netcdf_info(name='dilution',                    &
+                                          long_name='parcel dilution',             &
                                           std_name='',                             &
                                           unit='1',                                &
                                           dtype=NF90_DOUBLE)

--- a/src/3d/parcels/parcel_split.f90
+++ b/src/3d/parcels/parcel_split.f90
@@ -147,6 +147,10 @@ module parcel_split_mod
 #ifndef ENABLE_DRY_MODE
                 parcels%humidity(n_thread_loc) = parcels%humidity(n)
 #endif
+#ifdef ENABLE_LABELS
+                parcels%label(n_thread_loc) = parcels%label(n)
+                parcels%dilution(n_thread_loc) = parcels%dilution(n)
+#endif
                 V(:, 1) = V(:, 1) * dh * dsqrt(D(1))
                 parcels%position(:, n_thread_loc) = parcels%position(:, n) - V(:, 1)
                 parcels%position(:, n) = parcels%position(:, n) + V(:, 1)

--- a/src/netcdf/netcdf_reader.f90
+++ b/src/netcdf/netcdf_reader.f90
@@ -15,6 +15,7 @@ module netcdf_reader
         module procedure :: read_netcdf_dataset_2d
         module procedure :: read_netcdf_dataset_3d
         module procedure :: read_netcdf_dataset_1d_integer
+        module procedure :: read_netcdf_dataset_1d_int8
     end interface read_netcdf_dataset
 
     interface read_netcdf_attribute
@@ -172,6 +173,21 @@ module netcdf_reader
             ncerr = nf90_get_var(ncid=ncid, varid=varid, values=buffer, &
                                  start=start, count=cnt)
         end subroutine read_netcdf_dataset_1d_integer
+
+        subroutine read_netcdf_dataset_1d_int8(ncid, name, buffer, start, cnt)
+            integer,           intent(in)  :: ncid
+            character(*),      intent(in)  :: name
+            integer(kind=8),   intent(out) :: buffer(:)
+            integer, optional, intent(in)  :: start(:)
+            integer, optional, intent(in)  :: cnt(:)
+            integer                        :: varid
+
+            ncerr = nf90_inq_varid(ncid, name, varid)
+            call check_netcdf_error("Reading dataset id failed.")
+
+            ncerr = nf90_get_var(ncid=ncid, varid=varid, values=buffer, &
+                                 start=start, count=cnt)
+        end subroutine read_netcdf_dataset_1d_int8
 
         subroutine read_netcdf_dataset_1d(ncid, name, buffer, start, cnt)
             integer,           intent(in)  :: ncid

--- a/src/netcdf/netcdf_writer.f90
+++ b/src/netcdf/netcdf_writer.f90
@@ -29,6 +29,7 @@ module netcdf_writer
         module procedure write_netcdf_dataset_1d_integer
         module procedure write_netcdf_dataset_2d_integer
         module procedure write_netcdf_dataset_3d_integer
+        module procedure write_netcdf_dataset_1d_int8
     end interface write_netcdf_dataset
 
     interface write_netcdf_attribute
@@ -287,6 +288,24 @@ module netcdf_writer
             call check_netcdf_error("Failed to write dataset.")
 
         end subroutine write_netcdf_dataset_1d_integer
+
+        subroutine write_netcdf_dataset_1d_int8(ncid, varid, data, start, cnt, l_serial)
+            integer,           intent(in) :: ncid
+            integer,           intent(in) :: varid
+            integer(kind=8),   intent(in) :: data(:)
+            integer, optional, intent(in) :: start(:)
+            integer, optional, intent(in) :: cnt(:)
+            logical, optional, intent(in) :: l_serial
+
+            call set_collective_write(ncid, varid, l_serial)
+
+            ! write data
+            ncerr = nf90_put_var(ncid, varid, data, &
+                                 start=start, count = cnt)
+
+            call check_netcdf_error("Failed to write dataset.")
+
+        end subroutine write_netcdf_dataset_1d_int8
 
         subroutine write_netcdf_dataset_2d_integer(ncid, varid, data, start, cnt, l_serial)
             integer,           intent(in) :: ncid

--- a/src/utils/armanip.f90
+++ b/src/utils/armanip.f90
@@ -9,6 +9,7 @@ module armanip
 
     interface resize_array
         module procedure :: resize_array_1d
+        module procedure :: resize_array_1d_integer
         module procedure :: resize_array_2d
     end interface resize_array
 
@@ -45,6 +46,36 @@ module armanip
             call move_alloc(buffer, attr)
 
         end subroutine resize_array_1d
+
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+        ! Resize a one-dimensional array
+        ! @param[inout] attr the array
+        ! @param[in] new_size of the array
+        ! @param[in] n_copy number of elements to copy over
+        subroutine resize_array_1d_integer(attr, new_size, n_copy)
+            integer(kind=8), allocatable, intent(inout)  :: attr(:)
+            integer,                       intent(in)    :: new_size
+            integer, optional,             intent(in)    :: n_copy
+            integer(kind=8), allocatable                :: buffer(:)
+            integer                                      :: copy_size
+
+            copy_size = size(attr)
+            if (present(n_copy)) then
+                copy_size = n_copy
+            endif
+
+            if (new_size < copy_size) then
+                call mpi_exit_on_error("armanip::resize_array_1d: new_size < copy_size")
+            endif
+
+            allocate(buffer(new_size))
+
+            buffer(1:copy_size) = attr(1:copy_size)
+
+            call move_alloc(buffer, attr)
+
+        end subroutine resize_array_1d_integer
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
Hi @matt-frey. Here is the branch that adds labels for the workshop. It is disabled by default. We may still change the dilution at some point to deal with parcels with the same labels merging, but this is not as trivial as I thought. The other thing to consider is to reset the labels every time diagnostics are created. If we do this, we can create animations of parcel trajectories (won't have time to do this before the workshop, it also means tracking over longer time scales becomes more involved). 