### PR TITLE
Set total number of parcels before parcel_communicate

### DIFF
--- a/mpi-tests/benchmark_parcel_merging.f90
+++ b/mpi-tests/benchmark_parcel_merging.f90
@@ -70,8 +70,6 @@ program benchmark_parcel_merging
 
         call setup_parcels(xlen, ylen, zlen, l_shuffle, l_variable_nppc)
 
-        call parcel_communicate
-
         call stop_timer(generate_timer)
 
         n_total_parcels = 0
@@ -84,6 +82,10 @@ program benchmark_parcel_merging
                            MPI_SUM_64BIT,     &
                            world%comm,        &
                            world%err)
+
+        call parcel_communicate
+
+        call stop_timer(allreduce_timer)
 
         if (world%rank == world%root) then
             print *, "Number of parcels before merging:", n_total_parcels

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -434,7 +434,7 @@ module parcel_container
 #ifndef ENABLE_DRY_MODE
             parcels%humidity(n)     = buffer(IDX_HUM)
 #endif
-#ifndef ENABLE_DRY_MODE
+#ifdef ENABLE_LABELS
             parcels%label(n)        = nint(buffer(IDX_LABEL))
             parcels%dilution(n)     = buffer(IDX_DILUTION)
 #endif

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -62,11 +62,11 @@ module parcel_netcdf
 
 #ifndef ENABLE_DRY_MODE
     integer, parameter :: NC_HUM   = 19
-    
+
 #ifdef ENABLE_LABELS
-    integer, parameter :: NC_LABEL    = 20 & 
+    integer, parameter :: NC_LABEL    = 20 &
                        ,  NC_DILUTION = 21
-    
+
     type(netcdf_info) :: nc_dset(NC_DILUTION)
 #else
     type(netcdf_info) :: nc_dset(NC_HUM)
@@ -75,9 +75,9 @@ module parcel_netcdf
 #else
 
 #ifdef ENABLE_LABELS
-    integer, parameter :: NC_LABEL    = 19 & 
+    integer, parameter :: NC_LABEL    = 19 &
                        ,  NC_DILUTION = 20
-                       
+
     type(netcdf_info) :: nc_dset(NC_DILUTION)
 #else
     type(netcdf_info) :: nc_dset(NC_B23)
@@ -340,6 +340,7 @@ module parcel_netcdf
             endif
         end subroutine write_parcel_attribute
 
+#ifdef ENABLE_LABELS
         subroutine write_parcel_attribute_int(id, pdata, start, cnt)
             integer,          intent(in) :: id
             integer(kind=8),  intent(in) :: pdata(:)
@@ -351,6 +352,7 @@ module parcel_netcdf
                                           start, cnt)
             endif
         end subroutine write_parcel_attribute_int
+#endif
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
We must set the total number of parcels before calling `parcel_communicate` as otherwise it fails in debug mode due to checks.