### PR TITLE
Fix rejection method

### DIFF
--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -458,12 +458,12 @@ module parcel_netcdf
                 end_index = min(max_num_parcels, n_total)
                 pfirst = 1
                 n_remaining = n_total
+                n_parcels = 0
 
                 do while (start_index <= end_index)
 
                     n_read = end_index - start_index + 1
                     n_remaining = n_remaining - n_read
-                    n_parcels = pfirst + n_read - 1
 
                     call rejection_method(start_index, end_index, pfirst)
 


### PR DESCRIPTION
With https://github.com/EPIC-model/epic/commit/faa89ffa41515cb910d5e16b59e6c6e771c48c58#diff-aa80479ec21430b1df16920459f5125ea4b52bdc7c0f3c2e9bec2b9e13fe2e5dR478 we added a line to set / increment the number of parcels `n_parcels` which is used for the optimised rejection method (when `xlo`, `xhi`, `ylo` and `yhi` are present. However, this breaks the inefficient rejection method which already sets / updateds the number of parcels (here: https://github.com/EPIC-model/epic/pull/570/files#diff-aa80479ec21430b1df16920459f5125ea4b52bdc7c0f3c2e9bec2b9e13fe2e5dL466).