### PR TITLE
Explicit setter for type netcdf_info

### DIFF
--- a/src/3d/fields/field_diagnostics_netcdf.f90
+++ b/src/3d/fields/field_diagnostics_netcdf.f90
@@ -211,7 +211,7 @@ module field_diagnostics_netcdf
 
         subroutine set_netcdf_field_diagnostics_info
 
-            nc_dset(NC_RMS_VOL) = netcdf_info(                          &
+            call nc_dset(NC_RMS_VOL)%set_info(                          &
                 name='rms_v',                                           &
                 long_name='relative rms volume error',                  &
                 std_name='',                                            &
@@ -219,70 +219,70 @@ module field_diagnostics_netcdf
                 dtype=NF90_DOUBLE)
 
 
-            nc_dset(NC_ABS_ERR_VOL) = netcdf_info(                      &
+            call nc_dset(NC_ABS_ERR_VOL)%set_info(                      &
                 name='abserr_v',                                        &
                 long_name='max absolute normalised volume error',       &
                 std_name='',                                            &
                 unit='m^3',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_MAX_NPAR) = netcdf_info(                         &
+            call nc_dset(NC_MAX_NPAR)%set_info(                         &
                 name='max_npar',                                        &
                 long_name='max num parcels per cell',                   &
                 std_name='',                                            &
                 unit='1',                                               &
                 dtype=NF90_INT)
 
-            nc_dset(NC_MIN_NPAR) = netcdf_info(                         &
+            call nc_dset(NC_MIN_NPAR)%set_info(                         &
                 name='min_npar',                                        &
                 long_name='min num parcels per cell',                   &
                 std_name='',                                            &
                 unit='1',                                               &
                 dtype=NF90_INT)
 
-            nc_dset(NC_AVG_NPAR) = netcdf_info(                         &
+            call nc_dset(NC_AVG_NPAR)%set_info(                         &
                 name='avg_npar',                                        &
                 long_name='average num parcels per cell',               &
                 std_name='',                                            &
                 unit='1',                                               &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_AVG_NSPAR) = netcdf_info(                        &
+            call nc_dset(NC_AVG_NSPAR)%set_info(                        &
                 name='avg_nspar',                                       &
                 long_name='average num small parcels per cell',         &
                 std_name='',                                            &
                 unit='1',                                               &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_KE) = netcdf_info(                               &
+            call nc_dset(NC_KE)%set_info(                               &
                 name='ke',                                              &
                 long_name='domain-averaged kinetic energy',             &
                 std_name='',                                            &
                 unit='m^2/s^2',                                         &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_APE) = netcdf_info(                              &
+            call nc_dset(NC_APE)%set_info(                              &
                 name='ape',                                             &
                 long_name='domain-averaged available potential energy', &
                 std_name='',                                            &
                 unit='m^2/s^2',                                         &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_EN) = netcdf_info(                               &
+            call nc_dset(NC_EN)%set_info(                               &
                 name='en',                                              &
                 long_name='domain-averaged enstrophy',                  &
                 std_name='',                                            &
                 unit='1/s^2',                                           &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_MIN_BUOY) = netcdf_info(                         &
+            call nc_dset(NC_MIN_BUOY)%set_info(                         &
                 name='min_buoyancy',                                    &
                 long_name='minimum gridded buoyancy',                   &
                 std_name='',                                            &
                 unit='m/s^2',                                           &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_MAX_BUOY) = netcdf_info(                         &
+            call nc_dset(NC_MAX_BUOY)%set_info(                         &
                 name='max_buoyancy',                                    &
                 long_name='maximum gridded buoyancy',                   &
                 std_name='',                                            &

--- a/src/3d/fields/field_netcdf.f90
+++ b/src/3d/fields/field_netcdf.f90
@@ -462,99 +462,99 @@ module field_netcdf
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         subroutine set_netcdf_field_info
-            nc_dset(NC_X_VEL) = netcdf_info(name='x_velocity',                    &
+            call nc_dset(NC_X_VEL)%set_info(name='x_velocity',                    &
                                             long_name='x velocity component',     &
                                             std_name='',                          &
                                             unit='m/s',                           &
                                             dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Y_VEL) = netcdf_info(name='y_velocity',                    &
+            call nc_dset(NC_Y_VEL)%set_info(name='y_velocity',                    &
                                             long_name='y velocity component',     &
                                             std_name='',                          &
                                             unit='m/s',                           &
                                             dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Z_VEL) = netcdf_info(name='z_velocity',                    &
+            call nc_dset(NC_Z_VEL)%set_info(name='z_velocity',                    &
                                             long_name='z velocity component',     &
                                             std_name='',                          &
                                             unit='m/s',                           &
                                             dtype=NF90_DOUBLE)
 
-            nc_dset(NC_X_VTEND) = netcdf_info(name='x_vorticity_tendency',        &
+            call nc_dset(NC_X_VTEND)%set_info(name='x_vorticity_tendency',        &
                                               long_name='x vorticity tendency',   &
                                               std_name='',                        &
                                               unit='1/s',                         &
                                               dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Y_VTEND) = netcdf_info(name='y_vorticity_tendency',        &
+            call nc_dset(NC_Y_VTEND)%set_info(name='y_vorticity_tendency',        &
                                               long_name='y vorticity tendency',   &
                                               std_name='',                        &
                                               unit='1/s',                         &
                                               dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Z_VTEND) = netcdf_info(name='z_vorticity_tendency',        &
+            call nc_dset(NC_Z_VTEND)%set_info(name='z_vorticity_tendency',        &
                                               long_name='z vorticity tendency',   &
                                               std_name='',                        &
                                               unit='1/s',                         &
                                               dtype=NF90_DOUBLE)
 
-            nc_dset(NC_NPARG) = netcdf_info(name='nparg',                            &
+            call nc_dset(NC_NPARG)%set_info(name='nparg',                            &
                                             long_name='number of parcels per cell',  &
                                             std_name='',                             &
                                             unit='1',                                &
                                             dtype=NF90_INT)
 
-            nc_dset(NC_NSPARG) = netcdf_info(name='nsparg',                                &
+            call nc_dset(NC_NSPARG)%set_info(name='nsparg',                                &
                                              long_name='number of small parcels per cell', &
                                              std_name='',                                  &
                                              unit='1',                                     &
                                              dtype=NF90_INT)
 
-            nc_dset(NC_X_VOR) = netcdf_info(name='x_vorticity',                   &
+            call nc_dset(NC_X_VOR)%set_info(name='x_vorticity',                   &
                                             long_name='x vorticity component',    &
                                             std_name='',                          &
                                             unit='1/s',                           &
                                             dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Y_VOR) = netcdf_info(name='y_vorticity',                   &
+            call nc_dset(NC_Y_VOR)%set_info(name='y_vorticity',                   &
                                             long_name='y vorticity component',    &
                                             std_name='',                          &
                                             unit='1/s',                           &
                                             dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Z_VOR) = netcdf_info(name='z_vorticity',                   &
+            call nc_dset(NC_Z_VOR)%set_info(name='z_vorticity',                   &
                                             long_name='z vorticity component',    &
                                             std_name='',                          &
                                             unit='1/s',                           &
                                             dtype=NF90_DOUBLE)
 
-            nc_dset(NC_TBUOY) = netcdf_info(name='buoyancy',                      &
+            call nc_dset(NC_TBUOY)%set_info(name='buoyancy',                      &
                                             long_name='total buoyancy',           &
                                             std_name='',                          &
                                             unit='m/s^2',                         &
                                             dtype=NF90_DOUBLE)
 
 #ifndef ENABLE_DRY_MODE
-            nc_dset(NC_DBUOY) = netcdf_info(name='dry_buoyancy',                  &
+            call nc_dset(NC_DBUOY)%set_info(name='dry_buoyancy',                  &
                                             long_name='dry buoyancy',             &
                                             std_name='',                          &
                                             unit='m/s^2',                         &
                                             dtype=NF90_DOUBLE)
 
-            nc_dset(NC_HUM) = netcdf_info(name='humidity',                        &
+            call nc_dset(NC_HUM)%set_info(name='humidity',                        &
                                           long_name='specific humidity',          &
                                           std_name='',                            &
                                           unit='kg/kg',                           &
                                           dtype=NF90_DOUBLE)
 
-            nc_dset(NC_LBUOY) = netcdf_info(name='liquid_water_content',          &
+            call nc_dset(NC_LBUOY)%set_info(name='liquid_water_content',          &
                                             long_name='liquid-water content',     &
                                             std_name='',                          &
                                             unit='1',                             &
                                             dtype=NF90_DOUBLE)
 #endif
 
-            nc_dset(NC_VOL) = netcdf_info(name='volume',                          &
+            call nc_dset(NC_VOL)%set_info(name='volume',                          &
                                           long_name='volume',                     &
                                           std_name='',                            &
                                           unit='m^3',                             &

--- a/src/3d/parcels/parcel_diagnostics_netcdf.f90
+++ b/src/3d/parcels/parcel_diagnostics_netcdf.f90
@@ -260,28 +260,28 @@ module parcel_diagnostics_netcdf
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         subroutine set_netcdf_parcel_diagnostics_info
-            nc_dset(NC_APE) = netcdf_info(                                  &
+            call nc_dset(NC_APE)%set_info(                                  &
                 name='ape',                                                 &
                 long_name='domain-averaged available potential energy',     &
                 std_name='',                                                &
                 unit='m^2/s^2',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_KE) = netcdf_info(                                   &
+            call nc_dset(NC_KE)%set_info(                                   &
                 name='ke',                                                  &
                 long_name='domain-averaged kinetic energy',                 &
                 std_name='',                                                &
                 unit='m^2/s^2',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_TE) = netcdf_info(                                   &
+            call nc_dset(NC_TE)%set_info(                                   &
                 name='te',                                                  &
                 long_name='domain-averaged total energy',                   &
                 std_name='',                                                &
                 unit='m^2/s^2',                                             &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_EN) = netcdf_info(                                   &
+            call nc_dset(NC_EN)%set_info(                                   &
                 name='en',                                                  &
                 long_name='domain-averaged enstrophy',                      &
                 std_name='',                                                &
@@ -289,70 +289,70 @@ module parcel_diagnostics_netcdf
                 dtype=NF90_DOUBLE)
 
             ! write as a 64-bit double as netCDF only supports 32-bit integers
-            nc_dset(NC_NPAR) = netcdf_info(                                 &
+            call nc_dset(NC_NPAR)%set_info(                                 &
                 name='n_parcels',                                           &
                 long_name='number of parcels',                              &
                 std_name='',                                                &
                 unit='1',                                                   &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_NSPAR) = netcdf_info(                                &
+            call nc_dset(NC_NSPAR)%set_info(                                &
                 name='n_small_parcel',                                      &
                 long_name='number of small parcels',                        &
                 std_name='',                                                &
                 unit='1',                                                   &
                 dtype=NF90_INT)
 
-            nc_dset(NC_AVG_LAM) = netcdf_info(                              &
+            call nc_dset(NC_AVG_LAM)%set_info(                              &
                 name='avg_lam',                                             &
                 long_name='average aspect ratio',                           &
                 std_name='',                                                &
                 unit='1',                                                   &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_STD_LAM) = netcdf_info(                              &
+            call nc_dset(NC_STD_LAM)%set_info(                              &
                 name='std_lam',                                             &
                 long_name='standard deviation aspect ratio',                &
                 std_name='',                                                &
                 unit='1',                                                   &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_AVG_VOL) = netcdf_info(                              &
+            call nc_dset(NC_AVG_VOL)%set_info(                              &
                 name='avg_vol',                                             &
                 long_name='average volume',                                 &
                 std_name='',                                                &
                 unit='m^3',                                                 &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_STD_VOL) = netcdf_info(                              &
+            call nc_dset(NC_STD_VOL)%set_info(                              &
                 name='std_vol',                                             &
                 long_name='standard deviation volume',                      &
                 std_name='',                                                &
                 unit='m^3',                                                 &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_SUM_VOL) = netcdf_info(                              &
+            call nc_dset(NC_SUM_VOL)%set_info(                              &
                 name='sum_vol',                                             &
                 long_name='total volume',                                   &
                 std_name='',                                                &
                 unit='m^3',                                                 &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_RMS_X_VOR) = netcdf_info(                            &
+            call nc_dset(NC_RMS_X_VOR)%set_info(                            &
                 name='x_rms_vorticity',                                     &
                 long_name='root mean square of x vorticity component',      &
                 std_name='',                                                &
                 unit='1/s',                                                 &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_RMS_Y_VOR) = netcdf_info(                            &
+            call nc_dset(NC_RMS_Y_VOR)%set_info(                            &
                 name='y_rms_vorticity',                                     &
                 long_name='root mean square of y vorticity component',      &
                 std_name='',                                                &
                 unit='1/s',                                                 &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_RMS_Z_VOR) = netcdf_info(                            &
+            call nc_dset(NC_RMS_Z_VOR)%set_info(                            &
                 name='z_rms_vorticity',                                     &
                 long_name='root mean square of z vorticity component',      &
                 std_name='',                                                &
@@ -360,7 +360,7 @@ module parcel_diagnostics_netcdf
                 dtype=NF90_DOUBLE)
 
             ! write as a 64-bit double as netCDF only supports 32-bit integers
-            nc_dset(NC_NPAR_SPLIT) = netcdf_info(                           &
+            call nc_dset(NC_NPAR_SPLIT)%set_info(                           &
                 name='n_parcel_splits',                                     &
                  long_name='number of parcel splits since last time',       &
                  std_name='',                                               &
@@ -368,7 +368,7 @@ module parcel_diagnostics_netcdf
                  dtype=NF90_DOUBLE)
 
             ! write as a 64-bit double as netCDF only supports 32-bit integers
-            nc_dset(NC_NBIG_CLOSE) = netcdf_info(                           &
+            call nc_dset(NC_NBIG_CLOSE)%set_info(                           &
                 name='n_big_neighbour',                                     &
                  long_name='number of big parcel neighbours',               &
                  std_name='',                                               &
@@ -376,21 +376,21 @@ module parcel_diagnostics_netcdf
                  dtype=NF90_DOUBLE)
 
             ! write as a 64-bit double as netCDF only supports 32-bit integers
-            nc_dset(NC_NPAR_MERGE) = netcdf_info(                           &
+            call nc_dset(NC_NPAR_MERGE)%set_info(                           &
                 name='n_parcel_merges',                                     &
                  long_name='number of parcel merges since last time',       &
                  std_name='',                                               &
                  unit='1',                                                  &
                  dtype=NF90_DOUBLE)
 
-            nc_dset(NC_MIN_BUOY) = netcdf_info(                             &
+            call nc_dset(NC_MIN_BUOY)%set_info(                             &
                 name='min_buoyancy',                                        &
                 long_name='minimum parcel buoyancy',                        &
                 std_name='',                                                &
                 unit='m/s^2',                                               &
                 dtype=NF90_DOUBLE)
 
-            nc_dset(NC_MAX_BUOY) = netcdf_info(                             &
+            call nc_dset(NC_MAX_BUOY)%set_info(                             &
                 name='max_buoyancy',                                        &
                 long_name='maximum parcel buoyancy',                        &
                 std_name='',                                                &
@@ -398,7 +398,7 @@ module parcel_diagnostics_netcdf
                 dtype=NF90_DOUBLE)
 
             ! write as a 64-bit double as netCDF only supports 32-bit integers
-            nc_dset(NC_NWAY_MERGE) = netcdf_info(                           &
+            call nc_dset(NC_NWAY_MERGE)%set_info(                           &
                 name='n_way_merging',                                       &
                 long_name='n-way merging',                                  &
                 std_name='',                                                &

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -673,7 +673,7 @@ module parcel_netcdf
             ! reset the labels to Fortran index which corresponds to current label
             ! reset the dilution to get this from time step to time step
             do n = pfirst, plast
-               parcels%label(n) = first + n - pfirst 
+               parcels%label(n) = first + n - pfirst
                parcels%dilution(n) = 0
             end do
 #endif
@@ -818,129 +818,129 @@ module parcel_netcdf
 
         subroutine set_netcdf_parcel_info
 
-            nc_dset(NC_X_POS) = netcdf_info(name='x_position',                   &
+            call nc_dset(NC_X_POS)%set_info(name='x_position',                   &
                                             long_name='x position component',    &
                                             std_name='',                         &
                                             unit='m',                            &
                                             dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Y_POS) = netcdf_info(name='y_position',                   &
+            call nc_dset(NC_Y_POS)%set_info(name='y_position',                   &
                                             long_name='y position component',    &
                                             std_name='',                         &
                                             unit='m',                            &
                                             dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Z_POS) = netcdf_info(name='z_position',                   &
+            call nc_dset(NC_Z_POS)%set_info(name='z_position',                   &
                                             long_name='z position component',    &
                                             std_name='',                         &
                                             unit='m',                            &
                                             dtype=NF90_DOUBLE)
 
-            nc_dset(NC_START) = netcdf_info(name='start_index',                  &
+            call nc_dset(NC_START)%set_info(name='start_index',                  &
                                             long_name='MPI rank start index',    &
                                             std_name='',                         &
                                             unit='1',                            &
                                             dtype=NF90_INT)
 
-            nc_dset(NC_XLO) = netcdf_info(name='xlo',                           &
+            call nc_dset(NC_XLO)%set_info(name='xlo',                           &
                                           long_name='lower box boundary in x',  &
                                           std_name='',                          &
                                           unit='1',                             &
                                           dtype=NF90_INT)
 
-            nc_dset(NC_XHI) = netcdf_info(name='xhi',                           &
+            call nc_dset(NC_XHI)%set_info(name='xhi',                           &
                                           long_name='upper box boundary in x',  &
                                           std_name='',                          &
                                           unit='1',                             &
                                           dtype=NF90_INT)
 
-            nc_dset(NC_YLO) = netcdf_info(name='ylo',                           &
+            call nc_dset(NC_YLO)%set_info(name='ylo',                           &
                                           long_name='lower box boundary in y',  &
                                           std_name='',                          &
                                           unit='1',                             &
                                           dtype=NF90_INT)
 
-            nc_dset(NC_YHI) = netcdf_info(name='yhi',                           &
+            call nc_dset(NC_YHI)%set_info(name='yhi',                           &
                                           long_name='upper box boundary in y',  &
                                           std_name='',                          &
                                           unit='1',                             &
                                           dtype=NF90_INT)
 
-            nc_dset(NC_B11) = netcdf_info(name='B11',                              &
+            call nc_dset(NC_B11)%set_info(name='B11',                              &
                                           long_name='B11 element of shape matrix', &
                                           std_name='',                             &
                                           unit='m^2',                              &
                                           dtype=NF90_DOUBLE)
 
-            nc_dset(NC_B12) = netcdf_info(name='B12',                              &
+            call nc_dset(NC_B12)%set_info(name='B12',                              &
                                           long_name='B12 element of shape matrix', &
                                           std_name='',                             &
                                           unit='m^2',                              &
                                           dtype=NF90_DOUBLE)
 
-            nc_dset(NC_B13) = netcdf_info(name='B13',                              &
+            call nc_dset(NC_B13)%set_info(name='B13',                              &
                                           long_name='B13 element of shape matrix', &
                                           std_name='',                             &
                                           unit='m^2',                              &
                                           dtype=NF90_DOUBLE)
 
-            nc_dset(NC_B22) = netcdf_info(name='B22',                              &
+            call nc_dset(NC_B22)%set_info(name='B22',                              &
                                           long_name='B22 element of shape matrix', &
                                           std_name='',                             &
                                           unit='m^2',                              &
                                           dtype=NF90_DOUBLE)
 
-            nc_dset(NC_B23) = netcdf_info(name='B23',                              &
+            call nc_dset(NC_B23)%set_info(name='B23',                              &
                                           long_name='B23 element of shape matrix', &
                                           std_name='',                             &
                                           unit='m^2',                              &
                                           dtype=NF90_DOUBLE)
 
-            nc_dset(NC_VOL) = netcdf_info(name='volume',                           &
+            call nc_dset(NC_VOL)%set_info(name='volume',                           &
                                           long_name='parcel volume',               &
                                           std_name='',                             &
                                           unit='m^3',                              &
                                           dtype=NF90_DOUBLE)
 
-            nc_dset(NC_X_VOR) = netcdf_info(name='x_vorticity',                      &
+            call nc_dset(NC_X_VOR)%set_info(name='x_vorticity',                      &
                                             long_name='x vorticity component',       &
                                             std_name='',                             &
                                             unit='1/s',                              &
                                             dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Y_VOR) = netcdf_info(name='y_vorticity',                      &
+            call nc_dset(NC_Y_VOR)%set_info(name='y_vorticity',                      &
                                             long_name='y vorticity component',       &
                                             std_name='',                             &
                                             unit='1/s',                              &
                                             dtype=NF90_DOUBLE)
 
-            nc_dset(NC_Z_VOR) = netcdf_info(name='z_vorticity',                      &
+            call nc_dset(NC_Z_VOR)%set_info(name='z_vorticity',                      &
                                             long_name='z vorticity component',       &
                                             std_name='',                             &
                                             unit='1/s',                              &
                                             dtype=NF90_DOUBLE)
 
-            nc_dset(NC_BUOY) = netcdf_info(name='buoyancy',                         &
+            call nc_dset(NC_BUOY)%set_info(name='buoyancy',                         &
                                            long_name='parcel buoyancy',             &
                                            std_name='',                             &
                                            unit='m/s^2',                            &
                                            dtype=NF90_DOUBLE)
 
 #ifndef ENABLE_DRY_MODE
-            nc_dset(NC_HUM) = netcdf_info(name='humidity',                         &
+            call nc_dset(NC_HUM)%set_info(name='humidity',                         &
                                           long_name='parcel humidity',             &
                                           std_name='',                             &
                                           unit='1',                                &
                                           dtype=NF90_DOUBLE)
 #endif
 #ifdef ENABLE_LABELS
-            nc_dset(NC_LABEL) = netcdf_info(name='label',                          &
+            call nc_dset(NC_LABEL)%set_info(name='label',                          &
                                           long_name='parcel label',                &
                                           std_name='',                             &
                                           unit='1',                                &
                                           dtype=NF90_INT64)
 
-            nc_dset(NC_DILUTION) = netcdf_info(name='dilution',                    &
+            call nc_dset(NC_DILUTION)%set_info(name='dilution',                    &
                                           long_name='parcel log dilution',         &
                                           std_name='',                             &
                                           unit='1',                                &

--- a/src/netcdf/netcdf_utils.f90
+++ b/src/netcdf/netcdf_utils.f90
@@ -26,9 +26,37 @@ module netcdf_utils
         integer              :: dtype     = -1
         integer              :: varid     = -1
         logical              :: l_enabled = .false.
+
+        contains
+            procedure :: set_info
     end type netcdf_info
 
     contains
+
+        subroutine set_info(this, name, long_name, std_name, unit, dtype)
+            class(netcdf_info), intent(inout) :: this
+            character(*),       intent(in)    :: name
+            character(*),       intent(in)    :: long_name
+            character(*),       intent(in)    :: std_name
+            character(*),       intent(in)    :: unit
+            integer,            intent(in)    :: dtype
+            integer                           :: l
+
+            l = len(name)
+            this%name(1:l) = name
+
+            l = len(long_name)
+            this%long_name(1:l) = long_name
+
+            l = len(std_name)
+            this%std_name(1:l) = std_name
+
+            l = len(unit)
+            this%unit(1:l) = unit
+
+            this%dtype = dtype
+
+        end subroutine set_info
 
         ! This subroutine takes an array of length 3 or 4
         ! single characters defining the dimension names.

--- a/src/netcdf/netcdf_utils.f90
+++ b/src/netcdf/netcdf_utils.f90
@@ -43,15 +43,31 @@ module netcdf_utils
             integer                           :: l
 
             l = len(name)
+            if (l > len(this%name)) then
+                call mpi_stop(&
+                    "Error in netcdf_info::set_info: 'name' input '" // name // "' longer than allowed.")
+            endif
             this%name(1:l) = name
 
             l = len(long_name)
+            if (l > len(this%long_name)) then
+                call mpi_stop(&
+                    "Error in netcdf_info::set_info: 'long_name' input '" // long_name // "' longer than allowed.")
+            endif
             this%long_name(1:l) = long_name
 
             l = len(std_name)
+            if (l > len(this%std_name)) then
+                call mpi_stop(&
+                    "Error in netcdf_info::set_info: 'std_name' input '" // std_name // "' longer than allowed.")
+            endif
             this%std_name(1:l) = std_name
 
             l = len(unit)
+            if (l > len(this%unit)) then
+                call mpi_stop(&
+                    "Error in netcdf_info::set_info: 'unit' input '" // unit // "' longer than allowed.")
+            endif
             this%unit(1:l) = unit
 
             this%dtype = dtype


### PR DESCRIPTION
We are facing the issue of character string initialisation with (presumably) some compilers. The problem arises in the initialisation of the `netcdf_info` type. The assignment of character strings of shorter length than the actual type causes issues; e.g. a name like `x_velocity` suddently reads `x_volocity`. An explicit setter function fixes the issue.