### PR TITLE
Fix error in get_local_bounds

### DIFF
--- a/src/mpi/mpi_layout.f90
+++ b/src/mpi/mpi_layout.f90
@@ -291,7 +291,6 @@ module mpi_layout
             if (coords < remaining) then
                 nlocal = nlocal + 1
                 first = first + coords
-                last = last + coords
             else
                 first = first + remaining
             endif


### PR DESCRIPTION
The variable `last` is passed with `intent(out)`. We cannot use the variable before it is assigned. Also, this lines has no effect because a value is assigned to the variable at the end of the routine.